### PR TITLE
Add function to check for ignored providers

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,7 @@
+===
+API
+===
+
+Here's the public API for pipeline.
+
+.. autofunction:: pipeline.ignore_provider

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,8 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   api
+
 
 
 Indices and tables

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,1 +1,29 @@
 """Common utilities for the Ingestion Pipeline."""
+
+__all__ = ('ignore_provider',)
+
+
+def ignore_provider(provider, included=None, excluded=None):
+    """Return whether a provider should be ignored.
+
+    If ``included`` is not empty, this function will return ``False``
+    for any provider in the list and ``True`` for all other providers.
+    The provider will only be checked against ``excluded`` when
+    ``included`` is empty.
+
+    Args:
+        provider (str): The identifier of the provider to check.
+        included (list, optional): A list of all providers not to
+          ignore.
+        excluded (list, optional): A list of providers that should be
+          ignored.
+
+    Returns:
+        bool: True if the provider should be ignored.
+    """
+    if included:
+        # If there is a list of included providers, it is the only thing
+        # checked to determine whether or not to ignore the provider.
+        return provider not in included
+
+    return provider in (excluded or ())

--- a/tests/test_ignore_provider.py
+++ b/tests/test_ignore_provider.py
@@ -1,0 +1,45 @@
+"""Test ignore_provider."""
+
+from pipeline import ignore_provider
+
+TEST_PROVIDER = 'testing'
+
+
+def test_empty_lists():
+    """Test ignore_provider with empty lists of providers."""
+    assert not ignore_provider(TEST_PROVIDER, included=[], excluded=[])
+
+
+def test_excluded():
+    """Test ignore_provider with excluded providers."""
+    assert not ignore_provider(
+        TEST_PROVIDER, included=[], excluded=[TEST_PROVIDER + '1'])
+
+
+def test_excluded_ignore():
+    """Test ignore_provider ignores with excluded providers."""
+    assert ignore_provider(
+        TEST_PROVIDER, included=[], excluded=[TEST_PROVIDER])
+
+
+def test_included():
+    """Test ignore_provider with included providers."""
+    assert not ignore_provider(
+        TEST_PROVIDER, included=[TEST_PROVIDER], excluded=[])
+
+
+def test_included_ignore():
+    """Test ignore_provider ignores with included providers."""
+    assert ignore_provider(
+        TEST_PROVIDER, included=[TEST_PROVIDER + '1'], excluded=[])
+
+
+def test_included_and_excluded():
+    """Test ignore_provider with included and excluded providers."""
+    assert not ignore_provider(
+        TEST_PROVIDER, included=[TEST_PROVIDER], excluded=[TEST_PROVIDER])
+
+
+def test_none():
+    """Test ignore_provider with no providers."""
+    assert not ignore_provider(TEST_PROVIDER, included=None, excluded=None)


### PR DESCRIPTION
There will be services in the pipeline that won't operate on all
providers. Some will want to include only some providers while others
will want to exclude some. This new function will handle checking the
lists of providers to either include or to ignore.

When a list of providers to include is provided, the list of excluded
providers will be ignored.
