### PR TITLE
Add function to retrieve schema validation errors

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Release TBD
   structure
 - Add ``send_message`` to handle sending messages through the specified
   producer
+- Add function to iterate over schema validation error messages
 
 Version 0.1.2
 =============

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -26,3 +26,11 @@ Available schemas
 
 .. automodule:: pipeline.schema
    :members:
+   :exclude-members: iter_errors, ValidationError
+
+Error handling
+==============
+
+.. autoclass:: pipeline.schema.ValidationError
+
+.. autofunction:: pipeline.schema.iter_errors


### PR DESCRIPTION
While voluptuous provides access to all validation errors, they're only
accessible through the exception's `errors` property. We'll often want
to see all validation errors when reporting why a service failed. The
new `iter_errors` function will allow us to do that across all services
without having to repeat the awkward code to get the value associated
with a field.
