### PR TITLE
Add function to send errors

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,8 @@ Release TBD
 - Add ``send_message`` to handle sending messages through the specified
   producer
 - Add function to iterate over schema validation error messages
+- Add ``send_error`` to handle sending error messages through the specified
+  producer
 
 Version 0.1.2
 =============

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 import uuid
 
-__all__ = ('ignore_provider', 'prepare_message', 'send_message')
+__all__ = ('ignore_provider', 'prepare_message', 'send_error', 'send_message')
 
 
 def ignore_provider(provider, included=None, excluded=None):
@@ -55,6 +55,24 @@ def prepare_message(message, *, app_name, event):
     if not message.get('originated_at'):
         message['originated_at'] = message['updated_at']
     return message
+
+
+def send_error(message, *, producer):
+    """Send an error message.
+
+    ``message`` will be updated with the common message structure and
+    sent through the specified producer.
+
+    Args:
+        message (dict): The message to send.
+        producer: The product through which to send the message.
+
+    .. versionadded:: 0.2.0
+    """
+    # Preserve the incoming event.
+    prepared_message = prepare_message(
+        message, app_name=producer.app_name, event=message.get('event'))
+    producer.error(prepared_message)
 
 
 def send_message(message, *, producer, event):

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pipeline import prepare_message, send_message
+from pipeline import prepare_message, send_error, send_message
 
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 
@@ -78,6 +78,22 @@ def test_prepare_message_updated_at_is_datetime():
     actual = prepare_message({}, app_name='testing', event='tested')
     assert isinstance(
         datetime.strptime(actual['updated_at'], DATETIME_FORMAT), datetime)
+
+
+def test_send_error():
+    """Test that the provided message is sent."""
+    class Producer:
+        app_name = 'testing'
+        sent_message = None
+
+        def error(self, message):
+            self.sent_message = message
+
+    producer = Producer()
+    expected = {'message': 'test_message'}
+    send_error(expected, producer=producer)
+
+    assert producer.sent_message['message'] == expected['message']
 
 
 def test_send_message():


### PR DESCRIPTION
Services in the Ingestion Pipeline send messages through a producer. A
new function, `send_error`, is being added to pipeline to handle sending
error messages. This function will probably expand to handle the retry
versus failure logic as well.

While it was originally thought this would flow through `send_message`,
using a separate function simplifies the code.
