### PR TITLE
Only run builds for master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,8 @@ env:
   - TOX_ENV=docs
 script:
   - tox -e $TOX_ENV
+
+# Control the branches that get built.
+branches:
+  only:
+    - master


### PR DESCRIPTION
Running builds for pushes and pull requests causes two builds to happen
for each pull request. We want to run builds for pushes so that we can
ensure merging something into master doesn't cause the build to fail.
Travis supports a branches setting that can be used to limit (through a
whitelist or a blacklist) for which branches builds are run.

This change will limit builds to only master.
