### PR TITLE
Add function to allow schema validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     version='0.3.0',
     packages=find_packages(exclude=['tests']),
     install_requires=[
+        'Henson>=0.5.0',
         'python-decouple',
         'voluptuous',
     ],

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,6 +3,7 @@
 import json
 import os
 
+from henson.exceptions import Abort
 import pytest
 import voluptuous
 
@@ -128,3 +129,28 @@ def test_valid():
     """Test a valid document."""
     doc = load_json('valid.json')
     assert schema.track_bundle(doc) == doc
+
+
+@pytest.mark.parametrize('schema_, expected', (
+    (voluptuous.Schema(str), 'a'),
+    (voluptuous.Schema([int]), [1, 2]),
+    (
+        voluptuous.Schema({'a': int}, extra=voluptuous.ALLOW_EXTRA),
+        {'a': 1, 'b': 'c'}
+    ),
+))
+def test_validate_message(schema_, expected):
+    """Test a message that validates its schema."""
+    actual = schema.validate_schema(schema_, expected)
+    assert actual == expected
+
+
+@pytest.mark.parametrize('schema_, message', (
+    (voluptuous.Schema(str), 1),
+    (voluptuous.Schema([int]), [1, 'a']),
+    (voluptuous.Schema({'a': int}), {'a': 1, 'b': 2}),
+))
+def test_validate_message_invalid(schema_, message):
+    """Test that invalid messages fail to validate."""
+    with pytest.raises(Abort):
+        schema.validate_schema(schema_, message)


### PR DESCRIPTION
We always validate the schema of incoming messages. This function will
centralize some of the code for that. In addition to validating the
incoming message, it can log the error.

`validate_schema` is intended to be wrapped by a coroutine registered as
a message preprocessor. Upon failure, it will raise an `Abort`, telling
Henson to stop processing the message.

Because `Abort` wasn't added to Henson until version 0.5, Henson is
being added as a requirement to ensure that only supported versions are
used.
