### PR TITLE
Make ignore_provider a usable preprocessor

### DIFF
--- a/tests/test_ignore_provider.py
+++ b/tests/test_ignore_provider.py
@@ -2,9 +2,11 @@
 
 import pytest
 
+from henson.exceptions import Abort
 from pipeline import ignore_provider
 
 TEST_PROVIDER = 'testing'
+TEST_MESSAGE = {'provider': TEST_PROVIDER}
 
 
 @pytest.mark.asyncio
@@ -13,8 +15,8 @@ async def test_empty_lists(test_app):
     test_app.settings['INCLUDED_PROVIDERS'] = []
     test_app.settings['EXCLUDED_PROVIDERS'] = []
 
-    actual = await ignore_provider(test_app, TEST_PROVIDER)
-    assert not actual
+    actual = await ignore_provider(test_app, TEST_MESSAGE)
+    assert actual
 
 
 @pytest.mark.asyncio
@@ -23,8 +25,8 @@ async def test_excluded(test_app):
     test_app.settings['INCLUDED_PROVIDERS'] = []
     test_app.settings['EXCLUDED_PROVIDERS'] = [TEST_PROVIDER + '1']
 
-    actual = await ignore_provider(test_app, TEST_PROVIDER)
-    assert not actual
+    actual = await ignore_provider(test_app, TEST_MESSAGE)
+    assert actual
 
 
 @pytest.mark.asyncio
@@ -33,8 +35,8 @@ async def test_excluded_ignore(test_app):
     test_app.settings['INCLUDED_PROVIDERS'] = []
     test_app.settings['EXCLUDED_PROVIDERS'] = [TEST_PROVIDER]
 
-    actual = await ignore_provider(test_app, TEST_PROVIDER)
-    assert actual
+    with pytest.raises(Abort):
+        await ignore_provider(test_app, TEST_MESSAGE)
 
 
 @pytest.mark.asyncio
@@ -43,8 +45,8 @@ async def test_included(test_app):
     test_app.settings['INCLUDED_PROVIDERS'] = [TEST_PROVIDER]
     test_app.settings['EXCLUDED_PROVIDERS'] = []
 
-    actual = await ignore_provider(test_app, TEST_PROVIDER)
-    assert not actual
+    actual = await ignore_provider(test_app, TEST_MESSAGE)
+    assert actual
 
 
 @pytest.mark.asyncio
@@ -53,8 +55,8 @@ async def test_included_ignore(test_app):
     test_app.settings['INCLUDED_PROVIDERS'] = [TEST_PROVIDER + '1']
     test_app.settings['EXCLUDED_PROVIDERS'] = []
 
-    actual = await ignore_provider(test_app, TEST_PROVIDER)
-    assert actual
+    with pytest.raises(Abort):
+        await ignore_provider(test_app, TEST_MESSAGE)
 
 
 @pytest.mark.asyncio
@@ -63,8 +65,8 @@ async def test_included_and_excluded(test_app):
     test_app.settings['INCLUDED_PROVIDERS'] = [TEST_PROVIDER]
     test_app.settings['EXCLUDED_PROVIDERS'] = [TEST_PROVIDER]
 
-    actual = await ignore_provider(test_app, TEST_PROVIDER)
-    assert not actual
+    actual = await ignore_provider(test_app, TEST_MESSAGE)
+    assert actual
 
 
 @pytest.mark.asyncio
@@ -73,8 +75,8 @@ async def test_no_providers(test_app):
     test_app.settings.pop('INCLUDED_PROVIDERS', None)
     test_app.settings.pop('EXCLUDED_PROVIDERS', None)
 
-    actual = await ignore_provider(test_app, TEST_PROVIDER)
-    assert not actual
+    actual = await ignore_provider(test_app, TEST_MESSAGE)
+    assert actual
 
 
 @pytest.mark.asyncio
@@ -83,5 +85,5 @@ async def test_none(test_app):
     test_app.settings['INCLUDED_PROVIDERS'] = None
     test_app.settings['EXCLUDED_PROVIDERS'] = None
 
-    actual = await ignore_provider(test_app, TEST_PROVIDER)
-    assert not actual
+    actual = await ignore_provider(test_app, TEST_MESSAGE)
+    assert actual


### PR DESCRIPTION
`ignore_provider` will take the entire message rather than just the
provider so that it can be used as a preprocessor. Rather than returning
a boolean, `henson.exceptions.Abort` will be raised for ignored
providers, with the incoming message be returned otherwise.  This was
the intention of the changes introduced in fba2eec.
