### PR TITLE
Use producer.app.name instead of producer.app_name

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -100,7 +100,7 @@ async def send_error(message, *, producer):
     """
     # Preserve the incoming event.
     prepared_message = prepare_message(
-        message, app_name=producer.app_name, event=message.get('event'))
+        message, app_name=producer.app.name, event=message.get('event'))
     await producer.error(prepared_message)
 
 
@@ -122,5 +122,5 @@ async def send_message(message, *, producer, event):
     .. versionadded:: 0.2.0
     """
     prepared_message = prepare_message(
-        message, app_name=producer.app_name, event=event)
+        message, app_name=producer.app.name, event=event)
     await producer.send(prepared_message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,36 @@ class Application:
         self.settings = settings
 
 
+class Producer:
+    """A stub producer that can be used for testing.
+
+    Args:
+        app: The application for which this producer produces.
+    """
+
+    def __init__(self, app):
+        """Initialize the instance."""
+        self.app = app
+        self.sent_error = None
+        self.sent_message = None
+
+    async def error(self, message):
+        """Mock send an error message."""
+        self.sent_error = message
+
+    async def send(self, message):
+        """Mock send a message."""
+        self.sent_message = message
+
+
 @pytest.fixture
 def test_app():
     """Return a test application."""
     app = Application()
     return app
+
+
+@pytest.fixture
+def test_producer(test_app):
+    """Return a test producer."""
+    return Producer(test_app)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -83,34 +83,18 @@ def test_prepare_message_updated_at_is_datetime():
 
 
 @pytest.mark.asyncio
-async def test_send_error():
+async def test_send_error(test_producer):
     """Test that the provided message is sent."""
-    class Producer:
-        app_name = 'testing'
-        sent_message = None
-
-        async def error(self, message):
-            self.sent_message = message
-
-    producer = Producer()
     expected = {'message': 'test_message'}
-    await send_error(expected, producer=producer)
+    await send_error(expected, producer=test_producer)
 
-    assert producer.sent_message['message'] == expected['message']
+    assert test_producer.sent_error['message'] == expected['message']
 
 
 @pytest.mark.asyncio
-async def test_send_message():
+async def test_send_message(test_producer):
     """Test that the provided message is sent."""
-    class Producer:
-        app_name = 'testing'
-        sent_message = None
-
-        async def send(self, message):
-            self.sent_message = message
-
-    producer = Producer()
     expected = {'message': 'test_message'}
-    await send_message(expected, producer=producer, event='tested')
+    await send_message(expected, producer=test_producer, event='tested')
 
-    assert producer.sent_message['message'] == expected['message']
+    assert test_producer.sent_message['message'] == expected['message']


### PR DESCRIPTION
Producer classes provided by Henson-SQS and Henson-AMQP have no
attribute called `app_name`. Instead, a reference to the Application
object itself was added to both of these. This change allows calls to
`send_error` and `send_message` to work with the current (master)
versions of the plugins being used.
