### PR TITLE
Add coroutines to serialize/deserialize messages

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,8 @@ Release TBD
 - Add ``validate_schema`` to handle validating document schemas
 - Add additional fields to media schema for audio files
 - Remove settings module (*Backward Incompatible*)
+- Add ``jsonify`` and ``nosjify`` coroutines for serializing and deserializing
+  messages
 
 Version 0.2.0
 =============

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,11 +1,12 @@
 """Common utilities for the Ingestion Pipeline."""
 
 from datetime import datetime
+import json
 import uuid
 
 from henson.exceptions import Abort
 
-__all__ = ('ignore_provider', 'prepare_message', 'send_error', 'send_message')
+__all__ = ('ignore_provider', 'jsonify', 'nosjify', 'prepare_message', 'send_error', 'send_message')  # noqa
 
 
 async def ignore_provider(app, message):
@@ -55,6 +56,36 @@ async def ignore_provider(app, message):
         raise Abort('provider.ignored', message)
 
     return message
+
+
+async def jsonify(app, message):
+    """Return an encoded dictionary.
+
+    Args:
+        app (henson.base.Application): The application.
+        message (dict): The message to encode.
+
+    Returns:
+        bytes: The encoded message.
+
+    .. versionadded:: 0.3.0
+    """
+    return json.dumps(message).encode('utf-8')
+
+
+async def nosjify(app, message):
+    """Return a decoded dictionary.
+
+    Args:
+        app (henson.base.Application): The application.
+        message (bytes): The message to decode.
+
+    Returns:
+        dict: The decoded message.
+
+    .. versionadded:: 0.3.0
+    """
+    return json.loads(message.decode('utf-8'))
 
 
 def prepare_message(message, *, app_name, event):

--- a/tests/test_jsonify.py
+++ b/tests/test_jsonify.py
@@ -1,0 +1,21 @@
+"""Test jsonify."""
+
+import pytest
+
+from pipeline import jsonify, nosjify
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('expected', (
+    {'a': 1, 'b': 'c'},
+    {'a': {'b': {'c': 'd'}}},
+    [1, 2, 3, 4],
+    'a',
+    1,
+))
+async def test_jsonify(test_app, expected):
+    """Test jsonify."""
+    intermediate = await jsonify(test_app, expected)
+    actual = await nosjify(test_app, intermediate)
+    assert actual == expected
+    assert actual != intermediate


### PR DESCRIPTION
We want to work with dictionaries in our services, but some consumers
and producers require bytes. The new `jsonify` and `nosjify` coroutines
will handle serializing and deserializing the messages so that we can
get messages into the correct format without having to force a format
upon the plugins (and our callbacks).
