### PR TITLE
Serialize outgoing messages.

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -132,7 +132,9 @@ async def send_error(message, *, producer):
     # Preserve the incoming event.
     prepared_message = prepare_message(
         message, app_name=producer.app.name, event=message.get('event'))
-    await producer.error(prepared_message)
+    # TODO: This should be done in a separate step.
+    serialized_message = await jsonify(producer.app, prepared_message)
+    await producer.error(serialized_message)
 
 
 async def send_message(message, *, producer, event):
@@ -154,4 +156,6 @@ async def send_message(message, *, producer, event):
     """
     prepared_message = prepare_message(
         message, app_name=producer.app.name, event=event)
-    await producer.send(prepared_message)
+    # TODO: This should be done in a separate step.
+    serialized_message = await jsonify(producer.app, prepared_message)
+    await producer.send(serialized_message)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import pytest
 
-from pipeline import prepare_message, send_error, send_message
+from pipeline import nosjify, prepare_message, send_error, send_message
 
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 
@@ -87,8 +87,9 @@ async def test_send_error(test_producer):
     """Test that the provided message is sent."""
     expected = {'message': 'test_message'}
     await send_error(expected, producer=test_producer)
+    actual = await nosjify(None, test_producer.sent_error)
 
-    assert test_producer.sent_error['message'] == expected['message']
+    assert actual['message'] == expected['message']
 
 
 @pytest.mark.asyncio
@@ -96,5 +97,6 @@ async def test_send_message(test_producer):
     """Test that the provided message is sent."""
     expected = {'message': 'test_message'}
     await send_message(expected, producer=test_producer, event='tested')
+    actual = await nosjify(None, test_producer.sent_message)
 
-    assert test_producer.sent_message['message'] == expected['message']
+    assert actual['message'] == expected['message']


### PR DESCRIPTION
Ideally this should be handled by the services themselves, but
`prepare_message` can't easily be turned into a postprocessor. Due to
time constraints with testing the Ingestion Pipeline and getting out of
Carpathia, `send_message` and `send_error` will handle the serialization
for the time being.

This should be addressed as soon as possible.
