### PR TITLE
Hotfix for allowing nosjify to work with Henson-AMQP.

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -78,14 +78,15 @@ async def nosjify(app, message):
 
     Args:
         app (henson.base.Application): The application.
-        message (bytes): The message to decode.
+        message: An object with an attribute called ``body`` containing
+            the message to decode.
 
     Returns:
         dict: The decoded message.
 
     .. versionadded:: 0.3.0
     """
-    return json.loads(message.decode('utf-8'))
+    return json.loads(message.body.decode('utf-8'))
 
 
 def prepare_message(message, *, app_name, event):

--- a/tests/test_jsonify.py
+++ b/tests/test_jsonify.py
@@ -1,8 +1,12 @@
 """Test jsonify."""
 
+from collections import namedtuple
+
 import pytest
 
 from pipeline import jsonify, nosjify
+
+Message = namedtuple('Message', ('body',))
 
 
 @pytest.mark.asyncio
@@ -16,6 +20,7 @@ from pipeline import jsonify, nosjify
 async def test_jsonify(test_app, expected):
     """Test jsonify."""
     intermediate = await jsonify(test_app, expected)
-    actual = await nosjify(test_app, intermediate)
+    message = Message(intermediate)
+    actual = await nosjify(test_app, message)
     assert actual == expected
     assert actual != intermediate

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,5 +1,6 @@
 """Test message-related functionality."""
 
+from collections import namedtuple
 from datetime import datetime
 
 import pytest
@@ -7,6 +8,8 @@ import pytest
 from pipeline import nosjify, prepare_message, send_error, send_message
 
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
+
+Message = namedtuple('Message', ('body',))
 
 
 def test_prepare_message_adds_job_id():
@@ -87,7 +90,7 @@ async def test_send_error(test_producer):
     """Test that the provided message is sent."""
     expected = {'message': 'test_message'}
     await send_error(expected, producer=test_producer)
-    actual = await nosjify(None, test_producer.sent_error)
+    actual = await nosjify(None, Message(test_producer.sent_error))
 
     assert actual['message'] == expected['message']
 
@@ -97,6 +100,6 @@ async def test_send_message(test_producer):
     """Test that the provided message is sent."""
     expected = {'message': 'test_message'}
     await send_message(expected, producer=test_producer, event='tested')
-    actual = await nosjify(None, test_producer.sent_message)
+    actual = await nosjify(None, Message(test_producer.sent_message))
 
     assert actual['message'] == expected['message']


### PR DESCRIPTION
Henson-AMQP returns a `namedtuple` with an attribute called `body`
that contains the raw message being read. This fix allows nosjify to
work correctly until we can rethink how it should work.
