### PR TITLE
Add takedown and delivery schemas

### DIFF
--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -9,13 +9,11 @@ from functools import partial
 
 from henson.exceptions import Abort
 # Import multipleInvalid to expose it through the module.
-from voluptuous import MultipleInvalid, Optional, Schema, truth, TypeInvalid  # NOQA
+from voluptuous import Any, MultipleInvalid, Optional, Schema, truth, TypeInvalid  # NOQA
 
 __all__ = ('iter_errors', 'validate_schema')
 
 SchemaAllRequired = partial(Schema, required=True)
-
-VALID_ACTIONS = ('upsert', 'takedown')
 
 
 ValidationError = namedtuple('ValidationError', 'error message value')
@@ -30,19 +28,6 @@ Args:
 
 .. versionadded:: 0.2.0
 """
-
-
-@truth
-def _is_valid_action(action):
-    """Return if an action is valid.
-
-    Args:
-        action (str): The action to validate.
-
-    Returns:
-        bool: Whether the action is valid.
-    """
-    return action.lower() in VALID_ACTIONS
 
 
 def iter_errors(exc, data):
@@ -291,7 +276,7 @@ Args:
 
 # products
 product = SchemaAllRequired({
-    'action': _is_valid_action,
+    'action': 'upsert',
     'amw_key': str,
     'artist': artist,
     'copyright': copyright,
@@ -396,6 +381,25 @@ Args:
     upc (str): The track bundle's Universal Product Code.
     volume_count (int): The number of volumes that make up the track bundle.
 """
+
+takedown = SchemaAllRequired({
+    'action': 'takedown',
+    'amw_key': str,
+}, extra=True)
+"""Schema to validate a product takedown.
+
+Args:
+    action (str): The action to be taken on the product specified by
+        ``amw_key``. Must be ``'takedown'``.
+    amw_key (str): The product's amw_key.
+"""
+
+delivery = Any(track_bundle, takedown)
+"""Schema to validate a partner delivery.
+
+Content must match the schema of either ``takedown`` or ``track_bundle``.
+"""
+
 
 del track_schema
 del track_bundle_schema

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,6 @@
 """Test the schemas."""
 
+import copy
 import json
 import os
 
@@ -154,3 +155,35 @@ def test_validate_message_invalid(schema_, message):
     """Test that invalid messages fail to validate."""
     with pytest.raises(Abort):
         schema.validate_schema(schema_, message)
+
+
+def test_valid_takedown():
+    """Test that a valid takedown passes validation."""
+    full_doc = load_json('valid.json')
+    full_doc['action'] = 'takedown'
+    minimal_doc = {'action': 'takedown', 'amw_key': '123'}
+    actual_minimal_doc = schema.validate_schema(schema.takedown, minimal_doc)
+    actual_full_doc = schema.validate_schema(schema.takedown, full_doc)
+    assert actual_minimal_doc == minimal_doc
+    assert actual_full_doc == full_doc
+
+
+@pytest.mark.parametrize('message', (
+    {},
+    {'action': 'takedown'},
+    {'amw_key': '123'},
+    {'action': 'upsert', 'amw_key': '123'},
+))
+def test_invalid_takedown(message):
+    """Test invalid takedown delivery."""
+    with pytest.raises(Abort):
+        schema.validate_schema(schema.takedown, message)
+
+
+def test_delivery():
+    """Test delivery superset schema."""
+    upsert = load_json('valid.json')
+    takedown = copy.deepcopy(upsert)
+    takedown['action'] = 'takedown'
+    assert schema.validate_schema(schema.delivery, upsert) == upsert
+    assert schema.validate_schema(schema.delivery, takedown) == takedown


### PR DESCRIPTION
Takedowns require much less information than upserts, but they should
still be validated. A new `takedown` schema is added for that purpose.
Additionally, objectify and transform sometimes care that a delivery is
valid regardless of its type (e.g. when emitting or receiving a
message), so a new superschema called `delivery` is added for use in
those cases.

Logical change: previously, action validation tolerated case
differences. This is a lot of extra code for little benefit, so it's
being removed in favor of using the actions directly inside of the
schemas. If, in the future, we need to be more lenient with case
sensitivity, we can reintroduce this behavior.
