### PR TITLE
Make media optional

### DIFF
--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -281,7 +281,7 @@ product = SchemaAllRequired({
     'explicit_lyrics': bool,
     'genre': str,
     Optional('internal_id'): str,
-    'media': media,
+    Optional('media'): media,
     'provider': provider,
     Optional('publisher'): str,
     'sales_territories': [sales_territory],


### PR DESCRIPTION
Media files are not included with metadata-only deliveries. Objectify
has already been updated to exclude this section, but `pipeline.schema`
also needs the correct rule to validate outgoing deliveries.
