### PR TITLE
Make sub label names optional

### DIFF
--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -180,13 +180,13 @@ Args:
 
 # provider-related schemas
 sub_label = SchemaAllRequired({
-    'name': str,
+    Optional('name'): str,
     'countries': [str],
 })
 """Schema to valid a sub label.
 
 Args:
-    name (str): The sub label's name.
+    name (Optional[str]): The sub label's name.
     countries (list): A list of countries.
 """
 


### PR DESCRIPTION
While this seems like it shouldn't be a thing, we don't require names
for sub labels. (Any an example of this came up with a Sony delivery.)
Because of this, the key is being made optional.
