### PR TITLE
Add Travis CI notifications to Slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,5 @@ notifications:
     template:
       - '%{author} pushed "%{commit_subject}" (%{commit}) to <strong>%{repository_name}</strong>. %{message}<br><a href="%{compare_url}">View the pull request.</a><br><a href="%{build_url}">View build #%{build_number}.</a>'
     format: html
+  slack:
+    secure: AjzyBsgkXSOTjAxow1uOf5ShNR0QHzcNQ1sBk1LXCQCcsED1E9ouVdaQ3r9hHGbFVfe/E5f0Or4BQt+4QUoTZJp3AJJEo+b2mR+H8Yc5pmtTDoN/Q8QsBi1WxYLNCOp4AuLYFQx6qRE0Ub/Ubo5LpnpscC/Kq6RmUwKAAMVUXKqjbCwvLSpcKlO4EPuE89uHHDG8pbkxDeXZA3JvFLY7ICWgPXIJVPYoYkjUJKE6ui120pyDDPP8H7V5r6RVdNR1wGn1LmqT/2ucSYWVHUafYE7bUc8WDVglHDfcIl9Oq6lf4rOcM5mcpL/aoM1n+1MF/1w4xdtDyRGV0Pixso6fyL08+7sSE3/ojx0Vywyikx7WVbCyR9dSJ/K1m3KS00rh/OKSZB6QY5h1Crd54MAXPK7Qklq03yXJMI6RfOpk5+Tz6BW6LVkE2ovl/+8UTRu2TP+x6pPstwPtne+8Z1UIxzSH5r7e5gBoePY1kiRj5u4S127DtqZvj/ld4z/csXJWxVrusjsWSwOlq5d2d0tp/c/826BwO1KamV5/sZ9UMtTmIxZdlJbx3wqXqhqjslVngN9h6duy8kD+F2xIbR8o5dvuJ385TJo5CALS24y1nkW4MJUZYLOiIV0G+79Jrc86/nOIWKCRfRADlH2Gr/ZnzcaCQpS/cXLQTsm6SoILIUk=


### PR DESCRIPTION
This change will make Travis CI write notifications to Slack with the
status of pull requests.
