### PR TITLE
Support the new common message structure

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,12 +2,15 @@
 Changelog
 =========
 
-Version 0.5.0
+Version 1.0.0
 =============
 
 Release TBD
 
 - Add ``prepare_incoming_message`` to support the new common message structure
+- Rename ``prepare_message`` to ``prepare_outgoing_message`` and remove the
+  arguments that are no longer needed with the changes to the common message
+  structure (*backwards incompatible*)
 
 
 Version 0.4.0

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -7,7 +7,7 @@ import uuid
 
 from henson.exceptions import Abort
 
-__all__ = ('ignore_provider', 'jsonify', 'nosjify', 'prepare_incoming_message', 'prepare_message', 'send_error', 'send_message')  # noqa
+__all__ = ('ignore_provider', 'jsonify', 'nosjify', 'prepare_incoming_message', 'prepare_outgoing_message', 'send_error', 'send_message')  # noqa
 
 
 async def ignore_provider(app, message):
@@ -110,7 +110,7 @@ async def prepare_incoming_message(app, message):
     Returns:
         dict: The prepared message.
 
-    .. versionadded:: 0.5.0
+    .. versionadded:: 1.0.0
     """
     now = datetime.utcnow().isoformat()
 
@@ -134,26 +134,24 @@ async def prepare_incoming_message(app, message):
     return message
 
 
-def prepare_message(message, *, app_name, event):
+def prepare_outgoing_message(message):
     """Return a message with the common message structure.
 
     Args:
         message (dict): The message to prepare.
-        app_name (str): The name of the application sending the message.
-        event (str): The name of the event that created the message.
 
     Returns:
         dict: The prepared message.
+
+    .. versionchanged:: 1.0.0
+
+        With the changes made to the common message structure, most of
+        the functionality has been moved to
+        :func:`prepare_incoming_message`. The ``app_name`` and ``event``
+        arguments have been removed and the function has been renamed to
+        better distinguish itself from :func:`prepare_incoming_message`.
     """
-    # Make sure the job id exists and has a value.
-    if not message.get('job_id'):
-        message['job_id'] = str(uuid.uuid4())
-    message['app'] = app_name
-    message['event'] = event
-    message['updated_at'] = datetime.utcnow().isoformat()
-    # Make sure the origination time exists and has a value.
-    if not message.get('originated_at'):
-        message['originated_at'] = message['updated_at']
+    message['events'][-1]['updated_at'] = datetime.utcnow().isoformat()
     return message
 
 
@@ -168,8 +166,7 @@ async def send_error(message, *, producer):
         producer: The producer through which to send the message.
     """
     # Preserve the incoming event.
-    prepared_message = prepare_message(
-        message, app_name=producer.app.name, event=message.get('event'))
+    prepared_message = prepare_outgoing_message(message)
     # TODO: This should be done in a separate step.
     serialized_message = await jsonify(producer.app, prepared_message)
     await producer.error(serialized_message)
@@ -193,8 +190,7 @@ async def send_message(message, *, producer, event, routing_key=None):
 
         The ``routing_key`` argument is now supported.
     """
-    prepared_message = prepare_message(
-        message, app_name=producer.app.name, event=event)
+    prepared_message = prepare_outgoing_message(message)
     # TODO: This should be done in a separate step.
     serialized_message = await jsonify(producer.app, prepared_message)
     await producer.send(serialized_message, routing_key=routing_key)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pipeline',
-    version='0.5.0',
+    version='1.0.0',
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'Henson>=0.5.0',


### PR DESCRIPTION
We are making changes to the common message structure. The most notable
change is the introduction of a list of events. This change is being
made to help obtain our goal of storing a product's full history in a
single document (Elasticsearch).

To support this, two notable changes are being introduced:

1. A new coroutine, `prepare_incoming_message`, is being added to help
   initialize messages when they are received. It will assign the
   `job_id`, `originated_at` timestamp, and `events` list to new
   messages; copy the `message` to the previous event (if one exists),
   and generate an `event_id` and `received_at` timestamp for the
   current event.
2. `prepare_message` is being renamed to `prepare_outgoing_message`. The
   name change accompanies a signature change based on the reduced
   responsibility of the function; it not just sets a `completed_at`
   timestamp for the current event.

Due to the backwards incompatible changes made to
`prepare_outgoing_message`, the next release of `pipeline` will be 1.0
instead of 0.5.