### PR TITLE
Remove unused argument from send_message

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,8 @@ Release TBD
 - Rename ``prepare_message`` to ``prepare_outgoing_message`` and remove the
   arguments that are no longer needed with the changes to the common message
   structure (*backwards incompatible*)
+- ``send_message`` no longer accepts the ``event`` argument (*backwards
+  incompatible*)
 
 
 Version 0.4.0

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -172,7 +172,7 @@ async def send_error(message, *, producer):
     await producer.error(serialized_message)
 
 
-async def send_message(message, *, producer, event, routing_key=None):
+async def send_message(message, *, producer, routing_key=None):
     """Send an outgoing message.
 
     ``message`` will be updated with the common message structure and
@@ -181,10 +181,14 @@ async def send_message(message, *, producer, event, routing_key=None):
     Args:
         message (dict): The message to send.
         producer: The product through which to send the message.
-        event (str): The name of the event that created the message.
         routing_key (Optional[str]): The routing key to be passed
             through to the producer's ``send`` method. Defaults to
             ``None``.
+
+    .. versionchanged:: 1.0.0
+
+        The ``event`` argument is being removed because
+        ``prepare_outgoing_message`` no longer accepts it.
 
     .. versionchanged:: 0.4.0
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -111,7 +111,7 @@ async def test_send_error(test_producer):
 async def test_send_message(test_producer):
     """Test that the provided message is sent."""
     expected = {'message': 'test_message', 'events': [{}]}
-    await send_message(expected, producer=test_producer, event='tested')
+    await send_message(expected, producer=test_producer)
     actual = await nosjify(None, Message(test_producer.sent_message))
 
     assert actual['message'] == expected['message']


### PR DESCRIPTION
With the changes introduced in ec940a6, `prepare_outgoing_message` no
longer accepts the `event` as an argument. `send_message`'s `event`
argument existed solely to pass it along. It's no longer needed and is
being removed.