### PR TITLE
Remove an invalid comment and an unused import

### DIFF
--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from functools import partial
 
 from henson.exceptions import Abort
-from voluptuous import Any, MultipleInvalid, Optional, Schema, truth, TypeInvalid
+from voluptuous import Any, MultipleInvalid, Optional, Schema, TypeInvalid
 
 __all__ = ('iter_errors', 'validate_schema')
 


### PR DESCRIPTION
The comment about why `MultipleInvalid` was being imported no longer applied
once `validate_schema` was introduced in `a8d22af`. This also removes the need
for the `# NOQA` directive.

`voluptuous.truth` was no longer needed once `_is_valid_action` was removed in
d0f0369. Its import was hidden behind the `# NOQA` directive.