### PR TITLE
Add a way to fan one message out from another

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,8 @@ Version 1.1.0
 Release TBD
 
 - Update the message schema to a derivative of schema.org's MusicAlbum_
+- Add ``fanout`` to generate unique a ``job_id`` for outgoing messages sent by
+  services that send multiple outgoing messages for each incoming one
 
 Version 1.0.0
 =============


### PR DESCRIPTION
The current version of the common message structure allows for a
persistent message store to overwrite copies of the message with new
versions, using `'job_id'` as the index.. (This ability was enabled by
adding the `'events'` field.) The problem with this, however, is that
services in the Ingestion pipeline aren't always limited to one outgoing
message for each incoming message. In order to uniquely handle each
message sent through a service that sends multiple messages, there needs
to be a way to associated a new `job_id` with each outgoing message and
still preserve the link back to its incoming message.

A new function is being added to pipeline called `fanout` that will
handle all of the required behavior. To facilitate linking a message
back to its parent (and all of its ancestors),
`prepare_incoming_message` is going to added the initial
`'ancestor_ids'` field so that `fanout` can append to it.