### PR TITLE
Remove physical product-related fields from schema

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Release TBD
 - Update the message schema to a derivative of schema.org's MusicAlbum_
 - Add ``fanout`` to generate unique a ``job_id`` for outgoing messages sent by
   services that send multiple outgoing messages for each incoming one
+- Drop support for information related to physical products
 
 Version 1.0.0
 =============

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -225,19 +225,6 @@ Args:
     source (str): The location of the media file.
 """
 
-physical_product = SchemaAllRequired({
-    'byArtist': str,
-    'name': str,
-    'upc': str,
-})
-"""Schema to validate a physical product.
-
-Args:
-    byArtist (str): The name of the product's artist.
-    name (str): The product's name.
-    upc (str): The product's Universal Product Code.
-"""
-
 # provider-related schemas
 sub_label = SchemaAllRequired({
     Optional('name'): str,
@@ -412,7 +399,6 @@ track_bundle_schema.update({
     Optional('icpn'): str,
     'numTracks': int,
     'numVolumes': int,
-    Optional('physical'): physical_product,
     Optional('product_code'): str,
     'releasedEvent': Datetime('%Y-%m-%d'),
     'tracks': [track],
@@ -435,8 +421,6 @@ Args:
     numTracks (int): The number of tracks.
     numVolumes (int): The number of volumes that make up the
         track bundle.
-    physical: (Optional[physical_product]): The track bundle's physical
-        representation.
     product_code (Optional[str]): The track bundle's product code.
     releasedEvent (Date): The product's release date.
     tracks (list): A list of tracks.


### PR DESCRIPTION
We don't use the fields that track information about physical products
anywhere, nor do we track them for all of the providers. We've decided
to remove support for them from the database so there's no need to keep
them as part of the schema.