### PR TITLE
Add functionality to normalize identifiers

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,8 @@ Release TBD
 - Add ``fanout`` to generate unique a ``job_id`` for outgoing messages sent by
   services that send multiple outgoing messages for each incoming one
 - Drop support for information related to physical products
+- Add ``normalize_isrc`` and ``normalize_upc`` to handle transforming raw
+  identifiers into their normalized formats
 
 Version 1.0.0
 =============

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -7,7 +7,7 @@ import uuid
 
 from henson.exceptions import Abort
 
-__all__ = ('fanout', 'ignore_provider', 'jsonify', 'nosjify', 'prepare_incoming_message', 'prepare_outgoing_message', 'send_error', 'send_message')  # noqa
+__all__ = ('fanout', 'ignore_provider', 'jsonify', 'normalize_isrc', 'normalize_upc', 'nosjify', 'prepare_incoming_message', 'prepare_outgoing_message', 'send_error', 'send_message')  # noqa
 
 
 def fanout(message):
@@ -86,6 +86,45 @@ async def jsonify(app, message):
         bytes: The encoded message.
     """
     return json.dumps(message).encode('utf-8')
+
+
+def normalize_isrc(isrc):
+    """Return an ISRC in a normalized format.
+
+    ISRCs can be displayed with dashes to make them easier to read. The
+    values themselves, however, do not contain them. Before comparing
+    one ISRC to another, any dashes should be stripped.
+
+    Args:
+        isrc (str): The ISRC value to be transformed.
+
+    Returns:
+        str: The normalized ISRC.
+
+    .. versionadded:: 1.1.0
+    """
+    return isrc.replace('-', '')
+
+
+def normalize_upc(upc):
+    """Return a UPC to be a normalized format.
+
+    UPCs are 12-digit numeric codes. Longer values are generally GTINs
+    and should contain 12-digit UPCs padding with leading zeros. These
+    leading zeros can be stripped to create the UPC.
+
+    UPCs longer than 12 digits that don't start with leading zeros will
+    be returned without transformation.
+
+    Args:
+        upc (str): The UPC or GTIN value to be transformed.
+
+    Returns:
+        str: The normalized UPC.
+
+    .. versionadded:: 1.1.0
+    """
+    return upc.lstrip('0').zfill(12)
 
 
 async def nosjify(app, message):

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -370,6 +370,7 @@ track_schema.update({
     'genre': str,
     'index': int,
     'isrcCode': str,
+    Optional('isrcCodeRaw'): str,
     'number': int,
     Optional('participants'): [participant],
     'volume': int,
@@ -385,6 +386,8 @@ Args:
     index (int): The track's index on the track bundle. This is often,
         but not always, based on the ``number``.
     isrcCode (str): The track's International Standard Recording Code.
+    isrcCodeRaw (Optional(str)): The raw version of the track's
+        International Standard Recording Code.
     number (int): The track's number on the track bundle.
     volume (int): The number of the track bundle's volumes on which the
         track appears.
@@ -403,6 +406,7 @@ track_bundle_schema.update({
     'releasedEvent': Datetime('%Y-%m-%d'),
     'tracks': [track],
     'upc': str,
+    Optional('upcRaw'): str,
 })
 
 track_bundle = SchemaAllRequired(track_bundle_schema)
@@ -425,6 +429,8 @@ Args:
     releasedEvent (Date): The product's release date.
     tracks (list): A list of tracks.
     upc (str): The track bundle's Universal Product Code.
+    upcRaw (Optional(str)): The raw version of the track bundle's
+        Universal Product Code.
 """
 
 takedown = SchemaAllRequired({

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,106 @@
+"""Miscellaneous tests."""
+
+import pytest
+
+import pipeline
+
+
+@pytest.mark.parametrize('isrc, expected', (
+    ('12-345-67-89012', '123456789012'),
+    ('21-098-76-54321', '210987654321'),
+))
+def test_normalize_isrc(isrc, expected):
+    """Test that ISRCs with dashes are transformed."""
+    actual = pipeline.normalize_isrc(isrc)
+    assert actual == expected
+
+
+@pytest.mark.parametrize('isrc', (
+    '123456789012',
+    '210987654321',
+))
+def test_normalize_isrc_unchanged(isrc):
+    """Test that ISRCs without dashes are unchanged."""
+    assert isrc == pipeline.normalize_isrc(isrc)
+
+
+@pytest.mark.parametrize('upc, expected', (
+    ('00616892587125', '616892587125'),
+    ('00076743106828', '076743106828'),
+    ('00044003728271', '044003728271'),
+    ('00802097028420', '802097028420'),
+    ('00061528101723', '061528101723'),
+    ('00619061375226', '619061375226'),
+    ('00044003727151', '044003727151'),
+    ('00035561301228', '035561301228'),
+    ('00803467000923', '803467000923'),
+    ('00619061218523', '619061218523'),
+    ('00856811001800', '856811001800'),
+    ('00823674300234', '823674300234'),
+    ('00775020927629', '775020927629'),
+    ('00044003723795', '044003723795'),
+    ('00821826000162', '821826000162'),
+    ('00619061368020', '619061368020'),
+    ('00053361303525', '053361303525'),
+    ('00805386002729', '805386002729'),
+    ('00053361309428', '053361309428'),
+    ('00856811001794', '856811001794'),
+))
+def test_normalize_upc_leading_zeros(upc, expected):
+    """Test that UPCs with leading zeros are transformed."""
+    actual = pipeline.normalize_upc(upc)
+    assert actual == expected
+
+
+@pytest.mark.parametrize('upc', (
+    '80330753510997',
+    '80330753513226',
+    '80330753510362',
+    '80330753510447',
+    '80330753510317',
+    '80330753510355',
+    '80330753510300',
+    '80330753510430',
+    '80330753510324',
+    '80330753510348',
+    '80330753511376',
+    '80330753510539',
+    '80330753510157',
+    '80330753510423',
+    '80330753510607',
+    '80330753510461',
+    '80330753510577',
+    '80330753510188',
+    '80330753510393',
+    '80330753510560',
+))
+def test_normalize_upc_too_long_unchanged(upc):
+    """Test that UPCs that are too long are unchanged."""
+    assert upc == pipeline.normalize_upc(upc)
+
+
+@pytest.mark.parametrize('upc', (
+    '018736260971',
+    '616822105825',
+    '889845354086',
+    '111118824126',
+    '634479093388',
+    '889176232091',
+    '859715025446',
+    '702730622643',
+    '800684021212',
+    '811868219042',
+    '785688016726',
+    '889845213406',
+    '859712876850',
+    '885767949478',
+    '775957086963',
+    '803057002429',
+    '811868646121',
+    '829410132374',
+    '887516926396',
+    '642738977492',
+))
+def test_normalize_upc_valid_unchanged(upc):
+    """Test that valid UPCs are unchanged."""
+    assert upc == pipeline.normalize_upc(upc)


### PR DESCRIPTION
We store UPCs and ISRCs as they are sent to us by the labels. This leads
to problems matching against Napster's catalog because they normalize
the values first. Going forward we want to start storing both the
normalized and raw versions.