### PR TITLE
Make fanout available as a callback

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -10,7 +10,7 @@ from henson.exceptions import Abort
 __all__ = ('fanout', 'ignore_provider', 'jsonify', 'normalize_isrc', 'normalize_upc', 'nosjify', 'prepare_incoming_message', 'prepare_outgoing_message', 'send_error', 'send_message')  # noqa
 
 
-def fanout(message):
+async def fanout(app, message):
     """Return a message fanned out from the original message.
 
     Messages that are fanned out from other messages will receive a new
@@ -18,6 +18,8 @@ def fanout(message):
     list of ancestors.
 
     Args:
+        app (henson.base.Application): The application instance that
+            generated the message.
         message (dict): The original message.
 
     Returns:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -27,25 +27,28 @@ async def test_events_is_added(test_app):
     assert 'events' in actual
 
 
-def test_fanout_adds_ancestor_id():
+@pytest.mark.asyncio
+async def test_fanout_adds_ancestor_id(test_app):
     """Test that fanout adds the original job_id as an ancestor_id."""
     original = {'job_id': 1, 'ancestor_ids': []}
-    result = fanout(original)
+    result = await fanout(test_app, original)
     assert original['job_id'] in result['ancestor_ids']
 
 
-def test_fanout_does_not_change_original_message():
+@pytest.mark.asyncio
+async def test_fanout_does_not_change_original_message(test_app):
     """Test that fanout doesn't change the original message."""
     expected = 1
     original = {'job_id': expected, 'ancestor_ids': []}
-    result = fanout(original)
+    result = await fanout(test_app, original)
     assert original['job_id'] == expected
 
 
-def test_fanout_new_job_id():
+@pytest.mark.asyncio
+async def test_fanout_new_job_id(test_app):
     """Test that fanout assigns a new job_id."""
     original = {'job_id': 1, 'ancestor_ids': []}
-    result = fanout(original)
+    result = await fanout(test_app, original)
     assert result['job_id'] != original['job_id']
 
 


### PR DESCRIPTION
By switching `fanout` from a regular function to a coroutine with an
appropriate signature, applications can register it as a result
postprocessor, allowing its callback's logic to remain unchanged.