### PR TITLE
Clean up product schema

### DIFF
--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -128,7 +128,8 @@ def UseType(value):  # NOQA: N802
         list: The same useTypes passed into the function.
 
     Raises:
-        UseTypeInvalid: If one of the useTypes is not defined in USE_TYPES.
+        UseTypeInvalid: If one of the useTypes is not defined in
+            ``USE_TYPES``.
 
     .. versionadded: 1.1.0
     """
@@ -277,10 +278,10 @@ Args:
     territoryCode (str): The country code representing the territory.
     price (Optional[str]): The price used in the territory.
     useType (UseType): The types of usage that are allowed.
-    validFrom (Union[str, None]): The start date of the item's validity in
-        ISO-8601 format.
-    validThrough (Union[str, None]): The end date of the item's validity in
-        ISO-8601 format.
+    validFrom (Union[str, None]): The start date of the item's validity
+        in ISO-8601 format.
+    validThrough (Union[str, None]): The end date of the item's validity
+        in ISO-8601 format.
 """
 
 
@@ -406,7 +407,8 @@ Args:
 delivery = Any(track_bundle, takedown)
 """Schema to validate a partner delivery.
 
-Content must match the schema of either ``takedown`` or ``track_bundle``.
+Content must match the schema of either ``takedown`` or
+``track_bundle``.
 """
 
 

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -284,46 +284,6 @@ Args:
 """
 
 
-usage_rules = SchemaAllRequired({
-    'allow_bundle': bool,
-    'allow_burn_play_on_pc': bool,
-    'allow_burn_to_cd': bool,
-    'allow_mobile': bool,
-    'allow_permanent': bool,
-    'allow_promotional': bool,
-    'allow_streaming': bool,
-    'allow_subscription': bool,
-    'allow_transfer_to_nsdmi': bool,
-    'allow_transfer_to_sdmi': bool,
-    'allow_unbundle': bool,
-    'delete_on_clock_rollback': bool,
-    'disable_on_clock_rollback': bool,
-    'drm_free': bool,
-    'limited': bool,
-})
-"""Schema to validate usage rules.
-
-Args:
-    allow_bundle (bool): The allowbundle usage rule.
-    allow_burn_play_on_pc (bool): The allowburnplayonpc usage rule.
-    allow_burn_to_cd (bool): The allowburntocd usage rule.
-    allow_mobile (bool): The allowmobile usage rule.
-    allow_permanent (bool): The allowpermanent usage rule.
-    allow_promotional (bool): The allowpromotional usage rule.
-    allow_streaming (bool): The allowstreaming usage rule.
-    allow_subscription (bool): The allowsubscription usage rule.
-    allow_transfer_to_nsdmi (bool): The allowtransfertonsdmi usage rule.
-    allow_transfer_to_sdmi (bool): The allowtransfertosdmi usage rule.
-    allow_unbundle (bool): The allowunbundle usage rule.
-    delete_on_clock_rollback (bool): The deleteonclockrollback usage
-        rule.
-    disable_on_clock_rollback (bool): The disableonclockrollback usage
-        rule.
-    drm_free (bool): The drmfree usage rule.
-    limited (bool): The limited usage rule.
-"""
-
-
 # products
 product = SchemaAllRequired({
     'action': 'upsert',
@@ -339,7 +299,6 @@ product = SchemaAllRequired({
     'offers': [offer],
     'provider': provider,
     Optional('publisher'): str,
-    'usage_rules': usage_rules,
     Optional('version'): str,
 })
 """Schema to validate a product.
@@ -360,7 +319,6 @@ Args:
     offers (list): A list of offers for the product.
     provider (provider): The product's provider.
     publisher (Optional[str]): The product's publisher.
-    usage_rules (usage_rules): The product's usage rules.
     version (Optional[str]): The product's version.
 """
 

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -263,8 +263,8 @@ Args:
 offer = SchemaAllRequired({
     'commercialModelType': CommercialModelType,
     'licensee': str,
-    'territoryCode': str,
     Optional('price'): str,
+    'territoryCode': str,
     'useType': UseType,
     'validFrom': Any(Datetime(), None),
     'validThrough': Any(Datetime(), None),
@@ -275,8 +275,8 @@ Args:
     commercialModelType (CommercialModelType): The commercial model
         between the label or aggregator and their retail partners.
     licensee (str): The licensee for the offer.
-    territoryCode (str): The country code representing the territory.
     price (Optional[str]): The price used in the territory.
+    territoryCode (str): The country code representing the territory.
     useType (UseType): The types of usage that are allowed.
     validFrom (Union[str, None]): The start date of the item's validity
         in ISO-8601 format.

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -206,14 +206,14 @@ media = SchemaAllRequired({
     Optional('codec'): str,
     Optional('count'): int,
     Optional('number'): int,
-    Optional('sample_rate'): str,
+    Optional('sampleRate'): str,
     'source': str,
 })
 """Schema to validate media.
 
 ``count`` and ``number`` are more likely to be provided for images than
 for audio files. ``bitrate``, ``channel``, ``codec``, and
-``sample_rate`` are more likely for audio files.
+``sampleRate`` are more likely for audio files.
 
 Args:
     bitrate (Optional[str]): The bitrate of the media file.
@@ -221,7 +221,7 @@ Args:
     codec (Optional[str]): The codec of the media file.
     count (Optional[int]): The total number of media files.
     number (Optional[int]): The number of the media file.
-    sample_rate (Optional[str]): The sample rate of the media file.
+    sampleRate (Optional[str]): The sample rate of the media file.
     source (str): The location of the media file.
 """
 
@@ -239,13 +239,13 @@ Args:
 
 label = SchemaAllRequired({
     'name': str,
-    'sub_labels': [sub_label],
+    'subLabels': [sub_label],
 })
 """Schema to validate a label.
 
 Args:
     name (str): The label's name.
-    sub_labels (list): A list of sub labels.
+    subLabels (list): A list of sub labels.
 """
 
 provider = SchemaAllRequired({
@@ -287,13 +287,13 @@ Args:
 # products
 product = SchemaAllRequired({
     'action': 'upsert',
-    'amw_key': str,
+    'amwKey': str,
     'artist': artist,
     'copyright': copyright,
     'duration': str,
-    'explicit_lyrics': bool,
+    'explicitLyrics': bool,
     'genre': str,
-    Optional('internal_id'): str,
+    Optional('internalId'): str,
     Optional('media'): media,
     'name': str,
     'offers': [offer],
@@ -305,15 +305,15 @@ product = SchemaAllRequired({
 
 Args:
     action (str): The action to be taken on the product specified by
-        ``amw_key``. Must be ``'upsert'``.
-    amw_key (str): The product's unique identifier.
+        ``amwKey``. Must be ``'upsert'``.
+    amwKey (str): The product's unique identifier.
     artist (artist): The product's artist.
     copyright (copyright): The product's copyright.
     duration (str): The product's duration in ISO-8601 format.
-    explicit_lyrics (bool): Whether the product contains explicit
+    explicitLyrics (bool): Whether the product contains explicit
         lyrics.
     genre (str): The product's genre.
-    internal_id (Optional[int]): The track's internal identifier.
+    internalId (Optional[int]): The track's internal identifier.
     media (media): Media files associated with the product.
     name (str): The product's name.
     offers (list): A list of offers for the product.
@@ -354,13 +354,13 @@ Args:
 track_bundle_schema = product.schema.copy()
 track_bundle_schema.update({
     'albumReleaseType': str,
-    Optional('catalog_number'): str,
+    Optional('catalogNumber'): str,
     Optional('ean'): str,
     Optional('grid'): str,
     Optional('icpn'): str,
     'numTracks': int,
     'numVolumes': int,
-    Optional('product_code'): str,
+    Optional('productCode'): str,
     'releasedEvent': Datetime('%Y-%m-%d'),
     'tracks': [track],
     'upc': str,
@@ -374,7 +374,7 @@ This schema is an extension of the :data:`product` schema.
 
 Args:
     albumReleaseType (str): The product type.
-    catalog_number (Optional[str]): The track bundle's catalog number.
+    catalogNumber (Optional[str]): The track bundle's catalog number.
     ean (Optional[str]): The track bundle's International Article
         Number.
     grid (Optional[str]): The track bundle's Global Release Identifier.
@@ -383,7 +383,7 @@ Args:
     numTracks (int): The number of tracks.
     numVolumes (int): The number of volumes that make up the
         track bundle.
-    product_code (Optional[str]): The track bundle's product code.
+    productCode (Optional[str]): The track bundle's product code.
     releasedEvent (Date): The product's release date.
     tracks (list): A list of tracks.
     upc (str): The track bundle's Universal Product Code.
@@ -393,14 +393,14 @@ Args:
 
 takedown = SchemaAllRequired({
     'action': 'takedown',
-    'amw_key': str,
+    'amwKey': str,
 }, extra=True)
 """Schema to validate a product takedown.
 
 Args:
     action (str): The action to be taken on the product specified by
-        ``amw_key``. Must be ``'takedown'``.
-    amw_key (str): The product's amw_key.
+        ``amwKey``. Must be ``'takedown'``.
+    amwKey (str): The product's amwKey.
 """
 
 delivery = Any(track_bundle, takedown)

--- a/tests/data/schema/invalid-track-action.json
+++ b/tests/data/schema/invalid-track-action.json
@@ -86,44 +86,10 @@
                 }
             ],
             "title": "Title",
-            "usage_rules": {
-                "allow_bundle": true,
-                "allow_burn_play_on_pc": true,
-                "allow_burn_to_cd": true,
-                "allow_mobile": true,
-                "allow_permanent": true,
-                "allow_promotional": true,
-                "allow_streaming": true,
-                "allow_subscription": true,
-                "allow_transfer_to_nsdmi": true,
-                "allow_transfer_to_sdmi": true,
-                "allow_unbundle": true,
-                "delete_on_clock_rollback": true,
-                "disable_on_clock_rollback": true,
-                "drm_free": true,
-                "limited": true
-            },
             "volume": 1,
             "number": 1
         }
     ],
     "type": "Album",
-    "upc": "UPC",
-    "usage_rules": {
-        "allow_bundle": true,
-        "allow_burn_play_on_pc": true,
-        "allow_burn_to_cd": true,
-        "allow_mobile": true,
-        "allow_permanent": true,
-        "allow_promotional": true,
-        "allow_streaming": true,
-        "allow_subscription": true,
-        "allow_transfer_to_nsdmi": true,
-        "allow_transfer_to_sdmi": true,
-        "allow_unbundle": true,
-        "delete_on_clock_rollback": true,
-        "disable_on_clock_rollback": true,
-        "drm_free": true,
-        "limited": true
-    }
+    "upc": "UPC"
 }

--- a/tests/data/schema/invalid-track-action.json
+++ b/tests/data/schema/invalid-track-action.json
@@ -1,18 +1,18 @@
 {
     "action": "upsert",
-    "amw_key": "iHM_UPC",
+    "amwKey": "iHM_UPC",
     "artist": {
         "name": "Artist"
     },
-    "catalog_number": "catalognumber",
+    "catalogNumber": "catalognumber",
     "copyright": {
         "text": "2015 Copyright",
         "year": 2015
     },
     "duration": 1000,
-    "explicit_lyrics": true,
+    "explicitLyrics": true,
     "genre": "Rock",
-    "internal_id": "internalid",
+    "internalId": "internalid",
     "media": {
         "source": "/dev/null"
     },
@@ -21,7 +21,7 @@
         "labels": [
             {
                 "name": "Label",
-                "sub_labels": [
+                "subLabels": [
                     {
                         "countries": [
                             "CA",
@@ -47,7 +47,7 @@
     "title": "Title",
     "tracks": [
         {
-            "amw_key": "iHM_UPC_ISRC",
+            "amwKey": "iHM_UPC_ISRC",
             "artist": {
                 "name": "Artist"
             },
@@ -55,7 +55,7 @@
                 "text": "2015 Copyright",
                 "year": 2015
             },
-            "explicit_lyrics": false,
+            "explicitLyrics": false,
             "index": 0,
             "isrc": "ISRC",
             "genre": "Genre",
@@ -66,7 +66,7 @@
                 "labels": [
                     {
                         "name": "Label",
-                        "sub_labels": [
+                        "subLabels": [
                             {
                                 "countries": [
                                     "CA",

--- a/tests/data/schema/invalid-track-bundle-action.json
+++ b/tests/data/schema/invalid-track-bundle-action.json
@@ -1,18 +1,18 @@
 {
     "action": "notavalidaction",
-    "amw_key": "iHM_UPC",
+    "amwKey": "iHM_UPC",
     "artist": {
         "name": "Artist"
     },
-    "catalog_number": "catalognumber",
+    "catalogNumber": "catalognumber",
     "copyright": {
         "text": "2015 Copyright",
         "year": 2015
     },
     "duration": 1000,
-    "explicit_lyrics": true,
+    "explicitLyrics": true,
     "genre": "Rock",
-    "internal_id": "internalid",
+    "internalId": "internalid",
     "media": {
         "source": "/dev/null"
     },
@@ -22,7 +22,7 @@
         "labels": [
             {
                 "name": "Label",
-                "sub_labels": [
+                "subLabels": [
                     {
                         "countries": [
                             "CA",
@@ -49,7 +49,7 @@
     "tracks": [
         {
             "action": "upsert",
-            "amw_key": "iHM_UPC_ISRC",
+            "amwKey": "iHM_UPC_ISRC",
             "artist": {
                 "name": "Artist"
             },
@@ -57,7 +57,7 @@
                 "text": "2015 Copyright",
                 "year": 2015
             },
-            "explicit_lyrics": false,
+            "explicitLyrics": false,
             "index": 0,
             "isrc": "ISRC",
             "genre": "Genre",
@@ -68,7 +68,7 @@
                 "labels": [
                     {
                         "name": "Label",
-                        "sub_labels": [
+                        "subLabels": [
                             {
                                 "countries": [
                                     "CA",

--- a/tests/data/schema/invalid-track-bundle-action.json
+++ b/tests/data/schema/invalid-track-bundle-action.json
@@ -88,44 +88,10 @@
                 }
             ],
             "title": "Title",
-            "usage_rules": {
-                "allow_bundle": true,
-                "allow_burn_play_on_pc": true,
-                "allow_burn_to_cd": true,
-                "allow_mobile": true,
-                "allow_permanent": true,
-                "allow_promotional": true,
-                "allow_streaming": true,
-                "allow_subscription": true,
-                "allow_transfer_to_nsdmi": true,
-                "allow_transfer_to_sdmi": true,
-                "allow_unbundle": true,
-                "delete_on_clock_rollback": true,
-                "disable_on_clock_rollback": true,
-                "drm_free": true,
-                "limited": true
-            },
             "volume": 1,
             "number": 1
         }
     ],
     "type": "Album",
-    "upc": "UPC",
-    "usage_rules": {
-        "allow_bundle": true,
-        "allow_burn_play_on_pc": true,
-        "allow_burn_to_cd": true,
-        "allow_mobile": true,
-        "allow_permanent": true,
-        "allow_promotional": true,
-        "allow_streaming": true,
-        "allow_subscription": true,
-        "allow_transfer_to_nsdmi": true,
-        "allow_transfer_to_sdmi": true,
-        "allow_unbundle": true,
-        "delete_on_clock_rollback": true,
-        "disable_on_clock_rollback": true,
-        "drm_free": true,
-        "limited": true
-    }
+    "upc": "UPC"
 }

--- a/tests/data/schema/invalid-track-bundle-amwkey.json
+++ b/tests/data/schema/invalid-track-bundle-amwkey.json
@@ -3,15 +3,15 @@
     "artist": {
         "name": "Artist"
     },
-    "catalog_number": "catalognumber",
+    "catalogNumber": "catalognumber",
     "copyright": {
         "text": "2015 Copyright",
         "year": 2015
     },
     "duration": 1000,
-    "explicit_lyrics": true,
+    "explicitLyrics": true,
     "genre": "Rock",
-    "internal_id": "internalid",
+    "internalId": "internalid",
     "media": {
         "source": "/dev/null"
     },
@@ -21,7 +21,7 @@
         "labels": [
             {
                 "name": "Label",
-                "sub_labels": [
+                "subLabels": [
                     {
                         "countries": [
                             "CA",
@@ -48,7 +48,7 @@
     "tracks": [
         {
             "action": "upsert",
-            "amw_key": "iHM_UPC_ISRC",
+            "amwKey": "iHM_UPC_ISRC",
             "artist": {
                 "name": "Artist"
             },
@@ -56,7 +56,7 @@
                 "text": "2015 Copyright",
                 "year": 2015
             },
-            "explicit_lyrics": false,
+            "explicitLyrics": false,
             "index": 0,
             "isrc": "ISRC",
             "genre": "Genre",
@@ -67,7 +67,7 @@
                 "labels": [
                     {
                         "name": "Label",
-                        "sub_labels": [
+                        "subLabels": [
                             {
                                 "countries": [
                                     "CA",

--- a/tests/data/schema/invalid-track-bundle-amwkey.json
+++ b/tests/data/schema/invalid-track-bundle-amwkey.json
@@ -87,44 +87,10 @@
                 }
             ],
             "title": "Title",
-            "usage_rules": {
-                "allow_bundle": true,
-                "allow_burn_play_on_pc": true,
-                "allow_burn_to_cd": true,
-                "allow_mobile": true,
-                "allow_permanent": true,
-                "allow_promotional": true,
-                "allow_streaming": true,
-                "allow_subscription": true,
-                "allow_transfer_to_nsdmi": true,
-                "allow_transfer_to_sdmi": true,
-                "allow_unbundle": true,
-                "delete_on_clock_rollback": true,
-                "disable_on_clock_rollback": true,
-                "drm_free": true,
-                "limited": true
-            },
             "volume": 1,
             "number": 1
         }
     ],
     "type": "Album",
-    "upc": "UPC",
-    "usage_rules": {
-        "allow_bundle": true,
-        "allow_burn_play_on_pc": true,
-        "allow_burn_to_cd": true,
-        "allow_mobile": true,
-        "allow_permanent": true,
-        "allow_promotional": true,
-        "allow_streaming": true,
-        "allow_subscription": true,
-        "allow_transfer_to_nsdmi": true,
-        "allow_transfer_to_sdmi": true,
-        "allow_unbundle": true,
-        "delete_on_clock_rollback": true,
-        "disable_on_clock_rollback": true,
-        "drm_free": true,
-        "limited": true
-    }
+    "upc": "UPC"
 }

--- a/tests/data/schema/invalid-track-bundle-provider.json
+++ b/tests/data/schema/invalid-track-bundle-provider.json
@@ -1,18 +1,18 @@
 {
     "action": "upsert",
-    "amw_key": "iHM_UPC",
+    "amwKey": "iHM_UPC",
     "artist": {
         "name": "Artist"
     },
-    "catalog_number": "catalognumber",
+    "catalogNumber": "catalognumber",
     "copyright": {
         "text": "2015 Copyright",
         "year": 2015
     },
     "duration": 1000,
-    "explicit_lyrics": true,
+    "explicitLyrics": true,
     "genre": "Rock",
-    "internal_id": "internalid",
+    "internalId": "internalid",
     "media": {
         "source": "/dev/null"
     },
@@ -32,7 +32,7 @@
     "tracks": [
         {
             "action": "upsert",
-            "amw_key": "iHM_UPC_ISRC",
+            "amwKey": "iHM_UPC_ISRC",
             "artist": {
                 "name": "Artist"
             },
@@ -40,7 +40,7 @@
                 "text": "2015 Copyright",
                 "year": 2015
             },
-            "explicit_lyrics": false,
+            "explicitLyrics": false,
             "index": 0,
             "isrc": "ISRC",
             "genre": "Genre",
@@ -51,7 +51,7 @@
                 "labels": [
                     {
                         "name": "Label",
-                        "sub_labels": [
+                        "subLabels": [
                             {
                                 "countries": [
                                     "CA",

--- a/tests/data/schema/invalid-track-bundle-provider.json
+++ b/tests/data/schema/invalid-track-bundle-provider.json
@@ -71,44 +71,10 @@
                 }
             ],
             "title": "Title",
-            "usage_rules": {
-                "allow_bundle": true,
-                "allow_burn_play_on_pc": true,
-                "allow_burn_to_cd": true,
-                "allow_mobile": true,
-                "allow_permanent": true,
-                "allow_promotional": true,
-                "allow_streaming": true,
-                "allow_subscription": true,
-                "allow_transfer_to_nsdmi": true,
-                "allow_transfer_to_sdmi": true,
-                "allow_unbundle": true,
-                "delete_on_clock_rollback": true,
-                "disable_on_clock_rollback": true,
-                "drm_free": true,
-                "limited": true
-            },
             "volume": 1,
             "number": 1
         }
     ],
     "type": "Album",
-    "upc": "UPC",
-    "usage_rules": {
-        "allow_bundle": true,
-        "allow_burn_play_on_pc": true,
-        "allow_burn_to_cd": true,
-        "allow_mobile": true,
-        "allow_permanent": true,
-        "allow_promotional": true,
-        "allow_streaming": true,
-        "allow_subscription": true,
-        "allow_transfer_to_nsdmi": true,
-        "allow_transfer_to_sdmi": true,
-        "allow_unbundle": true,
-        "delete_on_clock_rollback": true,
-        "disable_on_clock_rollback": true,
-        "drm_free": true,
-        "limited": true
-    }
+    "upc": "UPC"
 }

--- a/tests/data/schema/invalid-track-bundle-title.json
+++ b/tests/data/schema/invalid-track-bundle-title.json
@@ -1,18 +1,18 @@
 {
     "action": "upsert",
-    "amw_key": "iHM_UPC",
+    "amwKey": "iHM_UPC",
     "artist": {
         "name": "Artist"
     },
-    "catalog_number": "catalognumber",
+    "catalogNumber": "catalognumber",
     "copyright": {
         "text": "2015 Copyright",
         "year": 2015
     },
     "duration": 1000,
-    "explicit_lyrics": true,
+    "explicitLyrics": true,
     "genre": "Rock",
-    "internal_id": "internalid",
+    "internalId": "internalid",
     "media": {
         "source": "/dev/null"
     },
@@ -22,7 +22,7 @@
         "labels": [
             {
                 "name": "Label",
-                "sub_labels": [
+                "subLabels": [
                     {
                         "countries": [
                             "CA",
@@ -48,7 +48,7 @@
     "tracks": [
         {
             "action": "upsert",
-            "amw_key": "iHM_UPC_ISRC",
+            "amwKey": "iHM_UPC_ISRC",
             "artist": {
                 "name": "Artist"
             },
@@ -56,7 +56,7 @@
                 "text": "2015 Copyright",
                 "year": 2015
             },
-            "explicit_lyrics": false,
+            "explicitLyrics": false,
             "index": 0,
             "isrc": "ISRC",
             "genre": "Genre",
@@ -67,7 +67,7 @@
                 "labels": [
                     {
                         "name": "Label",
-                        "sub_labels": [
+                        "subLabels": [
                             {
                                 "countries": [
                                     "CA",

--- a/tests/data/schema/invalid-track-bundle-title.json
+++ b/tests/data/schema/invalid-track-bundle-title.json
@@ -87,44 +87,10 @@
                 }
             ],
             "title": "Title",
-            "usage_rules": {
-                "allow_bundle": true,
-                "allow_burn_play_on_pc": true,
-                "allow_burn_to_cd": true,
-                "allow_mobile": true,
-                "allow_permanent": true,
-                "allow_promotional": true,
-                "allow_streaming": true,
-                "allow_subscription": true,
-                "allow_transfer_to_nsdmi": true,
-                "allow_transfer_to_sdmi": true,
-                "allow_unbundle": true,
-                "delete_on_clock_rollback": true,
-                "disable_on_clock_rollback": true,
-                "drm_free": true,
-                "limited": true
-            },
             "volume": 1,
             "number": 1
         }
     ],
     "type": "Album",
-    "upc": "UPC",
-    "usage_rules": {
-        "allow_bundle": true,
-        "allow_burn_play_on_pc": true,
-        "allow_burn_to_cd": true,
-        "allow_mobile": true,
-        "allow_permanent": true,
-        "allow_promotional": true,
-        "allow_streaming": true,
-        "allow_subscription": true,
-        "allow_transfer_to_nsdmi": true,
-        "allow_transfer_to_sdmi": true,
-        "allow_unbundle": true,
-        "delete_on_clock_rollback": true,
-        "disable_on_clock_rollback": true,
-        "drm_free": true,
-        "limited": true
-    }
+    "upc": "UPC"
 }

--- a/tests/data/schema/invalid-track-isrc.json
+++ b/tests/data/schema/invalid-track-isrc.json
@@ -87,44 +87,10 @@
                 }
             ],
             "title": "Title",
-            "usage_rules": {
-                "allow_bundle": true,
-                "allow_burn_play_on_pc": true,
-                "allow_burn_to_cd": true,
-                "allow_mobile": true,
-                "allow_permanent": true,
-                "allow_promotional": true,
-                "allow_streaming": true,
-                "allow_subscription": true,
-                "allow_transfer_to_nsdmi": true,
-                "allow_transfer_to_sdmi": true,
-                "allow_unbundle": true,
-                "delete_on_clock_rollback": true,
-                "disable_on_clock_rollback": true,
-                "drm_free": true,
-                "limited": true
-            },
             "volume": 1,
             "number": 1
         }
     ],
     "type": "Album",
-    "upc": "UPC",
-    "usage_rules": {
-        "allow_bundle": true,
-        "allow_burn_play_on_pc": true,
-        "allow_burn_to_cd": true,
-        "allow_mobile": true,
-        "allow_permanent": true,
-        "allow_promotional": true,
-        "allow_streaming": true,
-        "allow_subscription": true,
-        "allow_transfer_to_nsdmi": true,
-        "allow_transfer_to_sdmi": true,
-        "allow_unbundle": true,
-        "delete_on_clock_rollback": true,
-        "disable_on_clock_rollback": true,
-        "drm_free": true,
-        "limited": true
-    }
+    "upc": "UPC"
 }

--- a/tests/data/schema/invalid-track-isrc.json
+++ b/tests/data/schema/invalid-track-isrc.json
@@ -1,18 +1,18 @@
 {
     "action": "upsert",
-    "amw_key": "iHM_UPC",
+    "amwKey": "iHM_UPC",
     "artist": {
         "name": "Artist"
     },
-    "catalog_number": "catalognumber",
+    "catalogNumber": "catalognumber",
     "copyright": {
         "text": "2015 Copyright",
         "year": 2015
     },
     "duration": 1000,
-    "explicit_lyrics": true,
+    "explicitLyrics": true,
     "genre": "Rock",
-    "internal_id": "internalid",
+    "internalId": "internalid",
     "media": {
         "source": "/dev/null"
     },
@@ -22,7 +22,7 @@
         "labels": [
             {
                 "name": "Label",
-                "sub_labels": [
+                "subLabels": [
                     {
                         "countries": [
                             "CA",
@@ -49,7 +49,7 @@
     "tracks": [
         {
             "action": "upsert",
-            "amw_key": "iHM_UPC_ISRC",
+            "amwKey": "iHM_UPC_ISRC",
             "artist": {
                 "name": "Artist"
             },
@@ -57,7 +57,7 @@
                 "text": "2015 Copyright",
                 "year": 2015
             },
-            "explicit_lyrics": false,
+            "explicitLyrics": false,
             "index": 0,
             "genre": "Genre",
             "media": {
@@ -67,7 +67,7 @@
                 "labels": [
                     {
                         "name": "Label",
-                        "sub_labels": [
+                        "subLabels": [
                             {
                                 "countries": [
                                     "CA",

--- a/tests/data/schema/invalid-track-usage-rules.json
+++ b/tests/data/schema/invalid-track-usage-rules.json
@@ -88,41 +88,10 @@
                 }
             ],
             "title": "Title",
-            "usage_rules": {
-                "allow_bundle": true,
-                "allow_burn_play_on_pc": true,
-                "allow_mobile": true,
-                "allow_promotional": true,
-                "allow_subscription": true,
-                "allow_transfer_to_nsdmi": true,
-                "allow_transfer_to_sdmi": true,
-                "allow_unbundle": true,
-                "delete_on_clock_rollback": true,
-                "disable_on_clock_rollback": true,
-                "drm_free": true,
-                "limited": true
-            },
             "volume": 1,
             "number": 1
         }
     ],
     "type": "Album",
-    "upc": "UPC",
-    "usage_rules": {
-        "allow_bundle": true,
-        "allow_burn_play_on_pc": true,
-        "allow_burn_to_cd": true,
-        "allow_mobile": true,
-        "allow_permanent": true,
-        "allow_promotional": true,
-        "allow_streaming": true,
-        "allow_subscription": true,
-        "allow_transfer_to_nsdmi": true,
-        "allow_transfer_to_sdmi": true,
-        "allow_unbundle": true,
-        "delete_on_clock_rollback": true,
-        "disable_on_clock_rollback": true,
-        "drm_free": true,
-        "limited": true
-    }
+    "upc": "UPC"
 }

--- a/tests/data/schema/invalid-track-usage-rules.json
+++ b/tests/data/schema/invalid-track-usage-rules.json
@@ -1,18 +1,18 @@
 {
     "action": "upsert",
-    "amw_key": "iHM_UPC",
+    "amwKey": "iHM_UPC",
     "artist": {
         "name": "Artist"
     },
-    "catalog_number": "catalognumber",
+    "catalogNumber": "catalognumber",
     "copyright": {
         "text": "2015 Copyright",
         "year": 2015
     },
     "duration": 1000,
-    "explicit_lyrics": true,
+    "explicitLyrics": true,
     "genre": "Rock",
-    "internal_id": "internalid",
+    "internalId": "internalid",
     "media": {
         "source": "/dev/null"
     },
@@ -22,7 +22,7 @@
         "labels": [
             {
                 "name": "Label",
-                "sub_labels": [
+                "subLabels": [
                     {
                         "countries": [
                             "CA",
@@ -49,7 +49,7 @@
     "tracks": [
         {
             "action": "upsert",
-            "amw_key": "iHM_UPC_ISRC",
+            "amwKey": "iHM_UPC_ISRC",
             "artist": {
                 "name": "Artist"
             },
@@ -57,7 +57,7 @@
                 "text": "2015 Copyright",
                 "year": 2015
             },
-            "explicit_lyrics": false,
+            "explicitLyrics": false,
             "index": 0,
             "isrc": "ISRC",
             "genre": "Genre",
@@ -68,7 +68,7 @@
                 "labels": [
                     {
                         "name": "Label",
-                        "sub_labels": [
+                        "subLabels": [
                             {
                                 "countries": [
                                     "CA",

--- a/tests/data/schema/valid.json
+++ b/tests/data/schema/valid.json
@@ -1,19 +1,19 @@
 {
     "action": "upsert",
     "albumReleaseType": "Album",
-    "amw_key": "iHM_UPC",
+    "amwKey": "iHM_UPC",
     "artist": {
         "name": "Artist"
     },
-    "catalog_number": "catalognumber",
+    "catalogNumber": "catalognumber",
     "copyright": {
         "text": "2015 Copyright",
         "year": 2015
     },
     "duration": "P12H30M5S",
-    "explicit_lyrics": true,
+    "explicitLyrics": true,
     "genre": "Rock",
-    "internal_id": "internalid",
+    "internalId": "internalid",
     "media": {
         "source": "/dev/null"
     },
@@ -34,7 +34,7 @@
         "labels": [
             {
                 "name": "Label",
-                "sub_labels": [
+                "subLabels": [
                     {
                         "countries": [
                             "CA",
@@ -51,7 +51,7 @@
     "tracks": [
         {
             "action": "upsert",
-            "amw_key": "iHM_UPC_ISRC",
+            "amwKey": "iHM_UPC_ISRC",
             "artist": {
                 "name": "Artist"
             },
@@ -60,7 +60,7 @@
                 "year": 2015
             },
             "duration": "P12H30M5S",
-            "explicit_lyrics": false,
+            "explicitLyrics": false,
             "index": 0,
             "isrcCode": "ISRC",
             "genre": "Genre",
@@ -72,7 +72,7 @@
                 "labels": [
                     {
                         "name": "Label",
-                        "sub_labels": [
+                        "subLabels": [
                             {
                                 "countries": [
                                     "CA",

--- a/tests/data/schema/valid.json
+++ b/tests/data/schema/valid.json
@@ -95,43 +95,9 @@
                     "validThrough": "2016-10-24T14:01:57.102152Z"
                 }
             ],
-            "usage_rules": {
-                "allow_bundle": true,
-                "allow_burn_play_on_pc": true,
-                "allow_burn_to_cd": true,
-                "allow_mobile": true,
-                "allow_permanent": true,
-                "allow_promotional": true,
-                "allow_streaming": true,
-                "allow_subscription": true,
-                "allow_transfer_to_nsdmi": true,
-                "allow_transfer_to_sdmi": true,
-                "allow_unbundle": true,
-                "delete_on_clock_rollback": true,
-                "disable_on_clock_rollback": true,
-                "drm_free": true,
-                "limited": true
-            },
             "volume": 1,
             "number": 1
         }
     ],
-    "upc": "UPC",
-    "usage_rules": {
-        "allow_bundle": true,
-        "allow_burn_play_on_pc": true,
-        "allow_burn_to_cd": true,
-        "allow_mobile": true,
-        "allow_permanent": true,
-        "allow_promotional": true,
-        "allow_streaming": true,
-        "allow_subscription": true,
-        "allow_transfer_to_nsdmi": true,
-        "allow_transfer_to_sdmi": true,
-        "allow_unbundle": true,
-        "delete_on_clock_rollback": true,
-        "disable_on_clock_rollback": true,
-        "drm_free": true,
-        "limited": true
-    }
+    "upc": "UPC"
 }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -52,8 +52,8 @@ def test_empty_document():
 @pytest.mark.parametrize('message', (
     {},
     {'action': 'takedown'},
-    {'amw_key': '123'},
-    {'action': 'upsert', 'amw_key': '123'},
+    {'amwKey': '123'},
+    {'action': 'upsert', 'amwKey': '123'},
 ))
 def test_invalid_takedown(message):
     """Test invalid takedown delivery."""
@@ -117,7 +117,7 @@ def test_iter_errors_typeinvalid():
 
 def test_minimal_takendown():
     """Test that a valid minimal takedown passes validation."""
-    expected = {'action': 'takedown', 'amw_key': '123'}
+    expected = {'action': 'takedown', 'amwKey': '123'}
     actual = schema.validate_schema(schema.takedown, expected)
     assert actual == expected
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -122,13 +122,6 @@ def test_minimal_takendown():
     assert actual == expected
 
 
-def test_missing_track_usage_rules():
-    """Test that missing track usage rules doesn't validate."""
-    doc = load_json('invalid-track-usage-rules.json')
-    with pytest.raises(schema.MultipleInvalid):
-        schema.track_bundle(doc)
-
-
 def test_no_track_bundle_amwkey():
     """Test that a missing track bundle amwkey doesn't validate."""
     doc = load_json('invalid-track-bundle-amwkey.json')


### PR DESCRIPTION
Usage rules have been rolled into the `'offers'` field (along with sales
territories). Not only should we stop requiring them, we shouldn't even
continue to support them.

Rather than using camel case for public fields and snake case for internal
use-only fields, all fields should use the same case. Since this is
essentially a JSON schema, JSON's convention of camel case should be used.