### PR TITLE
Made the amwKey optional.

### DIFF
--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -288,7 +288,7 @@ Args:
 # products
 product = SchemaAllRequired({
     'action': 'upsert',
-    'amwKey': str,
+    Optional('amwKey'): str,
     'artist': artist,
     'copyright': copyright,
     'duration': str,
@@ -394,7 +394,7 @@ Args:
 
 takedown = SchemaAllRequired({
     'action': 'takedown',
-    'amwKey': str,
+    Optional('amwKey'): str,
 }, extra=True)
 """Schema to validate a product takedown.
 


### PR DESCRIPTION
Made the `amwkey` field optional, it does not need to be provided by a third party.
