### PR TITLE
Accept empty offers on product schema

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Release TBD
 - Add ``normalize_isrc`` and ``normalize_upc`` to handle transforming raw
   identifiers into their normalized formats
 - Add ``purge`` schema to handle Sony purge deliveries
+- Accept empty list as the ``offers`` field in ``product``
 
 Version 1.0.0
 =============

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -302,7 +302,7 @@ product = SchemaAllRequired({
     Optional('internalId'): str,
     Optional('media'): media,
     'name': str,
-    'offers': [offer],
+    Optional('offers'): [offer],
     'provider': provider,
     Optional('publisher'): str,
     Optional('version'): str,

--- a/tests/data/schema/valid.json
+++ b/tests/data/schema/valid.json
@@ -97,6 +97,46 @@
             ],
             "volume": 1,
             "number": 1
+        },
+        {
+            "action": "upsert",
+            "amwKey": "iHM_UPC_ISRC",
+            "artist": {
+                "name": "Artist"
+            },
+            "copyright": {
+                "text": "2015 Copyright",
+                "year": 2015
+            },
+            "duration": "P12H30M5S",
+            "explicitLyrics": false,
+            "index": 0,
+            "isrcCode": "ISRC",
+            "genre": "Genre",
+            "media": {
+                "source": "/dev/null"
+            },
+            "name": "Title",
+            "provider": {
+                "labels": [
+                    {
+                        "name": "Label",
+                        "subLabels": [
+                            {
+                                "countries": [
+                                    "CA",
+                                    "US"
+                                ],
+                                "name": "Sub Label"
+                            }
+                        ]
+                    }
+                ],
+                "name": "Provider"
+            },
+            "offers": [],
+            "volume": 1,
+            "number": 1
         }
     ],
     "upc": "UPC"


### PR DESCRIPTION
Made the change to the schema and added an offerless track to the valid delivery to cover that behavior.