### PR TITLE
Add Track GRid To Schema (Redux)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ Release TBD
   identifiers into their normalized formats
 - Add ``purge`` schema to handle Sony purge deliveries
 - Accept empty list as the ``offers`` field in ``product``
+- Add ``Optional`` track level ``grid`` validation
 
 Version 1.0.0
 =============

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -335,6 +335,7 @@ track_schema = product.schema.copy()
 track_schema.update({
     Optional('alternativeName'): str,
     'genre': str,
+    Optional('grid'): str,
     'index': int,
     'isrcCode': str,
     Optional('isrcCodeRaw'): str,
@@ -350,6 +351,7 @@ This schema is an extension of the :data:`product` schema.
 
 Args:
     alternativeName (Optional[str]): The track's extended name.
+    grid (Optional[str]): The track's Global Release Identifier.
     index (int): The track's index on the track bundle. This is often,
         but not always, based on the ``number``.
     isrcCode (str): The track's International Standard Recording Code.


### PR DESCRIPTION
Added `Optional` track level `grid` validation so we can begin to persist that field again.