### PR TITLE
Change Offers Date Validation To dateutil.parser.parse

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,8 @@ Release TBD
 - Add ``purge`` schema to handle Sony purge deliveries
 - Accept empty list as the ``offers`` field in ``product``
 - Add ``Optional`` track level ``grid`` validation
+- Swapped ``offers`` date parsing validation from
+  ``voluptuous.Datetime`` -> ``python-dateutil.parser``
 
 Version 1.0.0
 =============

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -5,6 +5,7 @@
 # cannot be consumed by help() or a REPL.
 
 from collections import namedtuple
+import dateutil.parser
 from functools import partial
 
 from henson.exceptions import Abort
@@ -145,6 +146,28 @@ def UseType(value):  # NOQA: N802
     return value
 
 
+def OffsetAwareDatetime(value):  # NOQA: N802
+    """Validate offset aware date time.
+
+    Args:
+        value (str): Date time.
+
+    Returns:
+        str: The same date time passed into the function.
+
+    Raises:
+        Invalid: If date time could not be parsed.
+
+    .. versionadded: 1.1.0
+
+    """
+    try:
+        dateutil.parser.parse(value)
+        return value
+    except (ValueError, OverflowError) as e:
+        raise Invalid('Could not parse date string: {}'.format(value))
+
+
 def validate_schema(schema, message, logger=None):
     """Validate a message against a schema.
 
@@ -272,8 +295,8 @@ offer = SchemaAllRequired({
     Optional('price'): str,
     'territoryCode': str,
     'useType': UseType,
-    'validFrom': Any(Datetime(), None),
-    'validThrough': Any(Datetime(), None),
+    'validFrom': Any(None, OffsetAwareDatetime),
+    'validThrough': Any(None, OffsetAwareDatetime),
 })
 """Schema to validate an offer.
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'Henson>=0.5.0',
+        'python-dateutil',
         'python-decouple',
         'voluptuous',
     ],

--- a/tests/data/schema/invalid-offer-commercial-model-type.json
+++ b/tests/data/schema/invalid-offer-commercial-model-type.json
@@ -1,0 +1,8 @@
+{
+    "commercialModelType": "Invalid",
+    "licensee": "iheart",
+    "territoryCode": "US",
+    "useType": ["ConditionalDownload"],
+    "validFrom": "2009-09-20T00:00:00.000000+00:00",
+    "validThrough": "2009-09-24T00:00:00.000000+00:00"
+} 

--- a/tests/data/schema/invalid-offer-licensee.json
+++ b/tests/data/schema/invalid-offer-licensee.json
@@ -1,0 +1,8 @@
+{
+    "commercialModelType": "SubscriptionModel",
+    "licensee": 555,
+    "territoryCode": "US",
+    "useType": ["ConditionalDownload"],
+    "validFrom": "2009-09-20T00:00:00.000000+00:00",
+    "validThrough": "2009-09-24T00:00:00.000000+00:00"
+} 

--- a/tests/data/schema/invalid-offer-territory-code.json
+++ b/tests/data/schema/invalid-offer-territory-code.json
@@ -1,0 +1,8 @@
+{
+    "commercialModelType": "SubscriptionModel",
+    "licensee": "iheart",
+    "territoryCode": 123,
+    "useType": ["ConditionalDownload"],
+    "validFrom": "2009-09-20T00:00:00.000000+00:00",
+    "validThrough": "2009-09-24T00:00:00.000000+00:00"
+} 

--- a/tests/data/schema/invalid-offer-use-type.json
+++ b/tests/data/schema/invalid-offer-use-type.json
@@ -1,0 +1,8 @@
+{
+    "commercialModelType": "SubscriptionModel",
+    "licensee": "iheart",
+    "territoryCode": "US",
+    "useType": ["Invalid"],
+    "validFrom": "2009-09-20T00:00:00.000000+00:00",
+    "validThrough": "2009-09-24T00:00:00.000000+00:00"
+} 

--- a/tests/data/schema/invalid-offer-valid-from.json
+++ b/tests/data/schema/invalid-offer-valid-from.json
@@ -1,0 +1,8 @@
+{
+    "commercialModelType": "SubscriptionModel",
+    "licensee": "iheart",
+    "territoryCode": "US",
+    "useType": ["ConditionalDownload"],
+    "validFrom": "Invalid",
+    "validThrough": "2009-09-24T00:00:00.000000+00:00"
+} 

--- a/tests/data/schema/invalid-offer-valid-to.json
+++ b/tests/data/schema/invalid-offer-valid-to.json
@@ -1,0 +1,8 @@
+{
+    "commercialModelType": "SubscriptionModel",
+    "licensee": "iheart",
+    "territoryCode": "US",
+    "useType": ["ConditionalDownload"],
+    "validFrom": "2009-09-20T00:00:00.000000+00:00",
+    "validThrough": "Invalid"
+} 

--- a/tests/data/schema/valid-offer.json
+++ b/tests/data/schema/valid-offer.json
@@ -1,0 +1,8 @@
+{
+    "commercialModelType": "SubscriptionModel",
+    "licensee": "iheart",
+    "territoryCode": "US",
+    "useType": ["ConditionalDownload"],
+    "validFrom": "2009-09-20T00:00:00.000000+00:00",
+    "validThrough": "2009-09-24T00:00:00.000000+00:00"
+} 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -232,3 +232,22 @@ def test_validate_message_invalid(schema_, message):
     """Test that invalid messages fail to validate."""
     with pytest.raises(Abort):
         schema.validate_schema(schema_, message)
+
+def test_valid_offer():
+    """Test a valid offer."""
+    doc = load_json('valid-offer.json')
+    assert schema.offer(doc) == doc
+
+@pytest.mark.parametrize('message', [
+    'invalid-offer-commercial-model-type.json',
+    'invalid-offer-licensee.json',
+    'invalid-offer-territory-code.json',
+    'invalid-offer-use-type.json',
+    'invalid-offer-valid-from.json',
+    'invalid-offer-valid-to.json',
+])
+def test_invalid_offer(message):
+    """Test that invalid offers fail to validate."""
+    doc = load_json(message)
+    with pytest.raises(schema.MultipleInvalid):
+        schema.offer(doc)


### PR DESCRIPTION
- swapped out the `voluptuous` `Datetime()` validator for a custom validator (`OffsetAwareDatetime`), that uses `python-dateutil` underneath the hood, so we can parse *any* UTC date with an offset value other than `Z`
- updated `changes.rst`
- unit tests to test valid and invalid (every type) `offers`

***NOTE***: The existing validation allows null values for `validFrom` and `validThrough`, so I kept it the same. Someone who cares should give the definitive answer to this.