### PR TITLE
Add None as acceptable for Optional fields.

### DIFF
--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -194,7 +194,7 @@ def validate_schema(schema, message, logger=None):
 # shared sub-types
 artist = SchemaAllRequired({
     'name': str,
-    Optional('url'): str,
+    Optional('url'): Any(str, None),
 })
 """Schema to validate an artist.
 
@@ -216,7 +216,7 @@ Args:
 
 copyright = SchemaAllRequired({
     'text': str,
-    Optional('year'): int,
+    Optional('year'): Any(int, None),
 })
 """Schema to validate a copyright.
 
@@ -230,12 +230,12 @@ Args:
 # and one for images. They can inherit from media like track and
 # track_bundle inherit from product.
 media = SchemaAllRequired({
-    Optional('bitrate'): str,
-    Optional('channel'): int,
-    Optional('codec'): str,
-    Optional('count'): int,
-    Optional('number'): int,
-    Optional('sampleRate'): str,
+    Optional('bitrate'): Any(str, None),
+    Optional('channel'): Any(int, None),
+    Optional('codec'): Any(str, None),
+    Optional('count'): Any(int, None),
+    Optional('number'): Any(int, None),
+    Optional('sampleRate'): Any(str, None),
     'source': str,
 })
 """Schema to validate media.
@@ -256,7 +256,7 @@ Args:
 
 # provider-related schemas
 sub_label = SchemaAllRequired({
-    Optional('name'): str,
+    Optional('name'): Any(str, None),
     'countries': [str],
 })
 """Schema to valid a sub label.
@@ -291,11 +291,11 @@ Args:
 offer = SchemaAllRequired({
     'commercialModelType': CommercialModelType,
     'licensee': str,
-    Optional('price'): str,
+    Optional('price'): Any(str, None),
     'territoryCode': str,
     'useType': UseType,
-    'validFrom': Any(None, OffsetAwareDatetime),
-    'validThrough': Any(None, OffsetAwareDatetime),
+    'validFrom': Any(OffsetAwareDatetime, None),
+    'validThrough': Any(OffsetAwareDatetime, None),
 })
 """Schema to validate an offer.
 
@@ -322,14 +322,14 @@ product = SchemaAllRequired({
     'duration': str,
     'explicitLyrics': bool,
     'genre': str,
-    Optional('id'): int,
-    Optional('internalId'): str,
-    Optional('media'): media,
+    Optional('id'): Any(int, None),
+    Optional('internalId'): Any(str, None),
+    Optional('media'): Any(media, None),
     'name': str,
     Optional('offers'): [offer],
     'provider': provider,
-    Optional('publisher'): str,
-    Optional('version'): str,
+    Optional('publisher'): Any(str, None),
+    Optional('version'): Any(str, None),
 })
 """Schema to validate a product.
 
@@ -355,14 +355,14 @@ Args:
 
 track_schema = product.schema.copy()
 track_schema.update({
-    Optional('alternativeName'): str,
+    Optional('alternativeName'): Any(str, None),
     'genre': str,
-    Optional('grid'): str,
+    Optional('grid'): Any(str, None),
     'index': int,
     'isrcCode': str,
-    Optional('isrcCodeRaw'): str,
+    Optional('isrcCodeRaw'): Any(str, None),
     'number': int,
-    Optional('participants'): [participant],
+    Optional('participants'): Any([participant], None),
     'volume': int,
 })
 
@@ -387,17 +387,17 @@ Args:
 track_bundle_schema = product.schema.copy()
 track_bundle_schema.update({
     'albumReleaseType': str,
-    Optional('catalogNumber'): str,
-    Optional('ean'): str,
-    Optional('grid'): str,
-    Optional('icpn'): str,
+    Optional('catalogNumber'): Any(str, None),
+    Optional('ean'): Any(str, None),
+    Optional('grid'): Any(str, None),
+    Optional('icpn'): Any(str, None),
     'numTracks': int,
     'numVolumes': int,
-    Optional('productCode'): str,
+    Optional('productCode'): Any(str, None),
     'releasedEvent': OffsetAwareDatetime,
     'tracks': [track],
     'upc': str,
-    Optional('upcRaw'): str,
+    Optional('upcRaw'): Any(str, None),
 })
 
 track_bundle = SchemaAllRequired(track_bundle_schema)

--- a/tests/data/schema/valid-nulled-schema.json
+++ b/tests/data/schema/valid-nulled-schema.json
@@ -1,0 +1,144 @@
+{
+    "action": "upsert",
+    "albumReleaseType": "Single",
+    "amwKey": "EMS_4260100940705",
+    "artist": {
+        "name": "Fäbson"
+    },
+    "catalogNumber": "4260100940705",
+    "copyright": {
+        "text": "ILM Records",
+        "year": null
+    },
+    "duration": "PT3M55S",
+    "ean": null,
+    "explicitLyrics": false,
+    "genre": "Deutschspr. HipHop /- Rap",
+    "grid": null,
+    "icpn": null,
+    "internalId": null,
+    "media": {
+        "count": null,
+        "number": null,
+        "source": "/test-bucket/4260100940705_1200.jpg"
+    },
+    "name": "Mama",
+    "numTracks": 1,
+    "numVolumes": 1,
+    "offers": [
+        {
+            "commercialModelType": "SubscriptionModel",
+            "licensee": "iheart",
+            "territoryCode": "WW",
+            "useType": [
+                "OnDemandStream",
+                "ConditionalDownload"
+            ],
+            "validFrom": "2017-09-15T00:00:00.000000+00:00",
+            "validThrough": "2100-01-01T00:00:00.000000+00:00"
+        },
+        {
+            "commercialModelType": "AdvertisementSupportedModel",
+            "licensee": "iheart",
+            "territoryCode": "WW",
+            "useType": [
+                "NonInteractiveStream"
+            ],
+            "validFrom": "2017-09-15T00:00:00.000000+00:00",
+            "validThrough": "2100-01-01T00:00:00.000000+00:00"
+        }
+    ],
+    "productCode": null,
+    "provider": {
+        "labels": [
+            {
+                "name": "ILM Records",
+                "subLabels": [
+                    {
+                        "countries": [
+                            "ALL"
+                        ],
+                        "name": null
+                    }
+                ]
+            }
+        ],
+        "name": "Zebralution GmbH"
+    },
+    "publisher": "ILM Records",
+    "releasedEvent": "2017-09-15",
+    "tracks": [
+        {
+            "action": "upsert",
+            "alternativeName": "Mama",
+            "amwKey": "EMS_4260100940705_DEUD91708166_1_1",
+            "artist": {
+                "name": "Fäbson"
+            },
+            "copyright": {
+                "text": "ILM Records",
+                "year": null
+            },
+            "duration": "PT3M55S",
+            "explicitLyrics": false,
+            "genre": "Deutschspr. HipHop /- Rap",
+            "grid": null,
+            "index": 0,
+            "internalId": null,
+            "isrcCode": "DEUD91708166",
+            "media": {
+                "bitrate": null,
+                "channel": null,
+                "codec": null,
+                "sampleRate": null,
+                "source": "/test-bucket/4260100940705_001_001_v1411.flac"
+            },
+            "name": "Mama",
+            "number": 1,
+            "offers": [
+                {
+                    "commercialModelType": "SubscriptionModel",
+                    "licensee": "iheart",
+                    "territoryCode": "AU",
+                    "useType": [
+                        "OnDemandStream",
+                        "ConditionalDownload"
+                    ],
+                    "validFrom": "2017-09-15T00:00:00.000000+00:00",
+                    "validThrough": "2100-01-01T00:00:00.000000+00:00"
+                },
+                {
+                    "commercialModelType": "AdvertisementSupportedModel",
+                    "licensee": "iheart",
+                    "territoryCode": "AU",
+                    "useType": [
+                        "NonInteractiveStream"
+                    ],
+                    "validFrom": "2017-09-15T00:00:00.000000+00:00",
+                    "validThrough": "2100-01-01T00:00:00.000000+00:00"
+                }
+            ],
+            "provider": {
+                "labels": [
+                    {
+                        "name": "ILM Records",
+                        "subLabels": [
+                            {
+                                "countries": [
+                                    "ALL"
+                                ],
+                                "name": "ILM Records"
+                            }
+                        ]
+                    }
+                ],
+                "name": "Zebralution GmbH"
+            },
+            "publisher": null,
+            "version": null,
+            "volume": 1
+        }
+    ],
+    "upc": "4260100940705",
+    "version": null
+}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -233,10 +233,12 @@ def test_validate_message_invalid(schema_, message):
     with pytest.raises(Abort):
         schema.validate_schema(schema_, message)
 
+
 def test_valid_offer():
     """Test a valid offer."""
     doc = load_json('valid-offer.json')
     assert schema.offer(doc) == doc
+
 
 @pytest.mark.parametrize('message', [
     'invalid-offer-commercial-model-type.json',
@@ -251,3 +253,9 @@ def test_invalid_offer(message):
     doc = load_json(message)
     with pytest.raises(schema.MultipleInvalid):
         schema.offer(doc)
+
+
+def test_valid_null_fields():
+    """Test a valid document with optional null fields."""
+    doc = load_json('valid-nulled-schema.json')
+    assert schema.track_bundle(doc) == doc


### PR DESCRIPTION
Using voluptuous' `Any()` to added `None` to product documents passed in by `detox`. 


These are the two services that would be affected by this and need to be updated:
https://github.com/iheartradio/objectify/search?q=pipeline.schema&unscoped_q=pipeline.schema
https://github.com/iheartradio/persist/search?q=pipeline.schema&unscoped_q=pipeline.schema

I pull the latest branches for these two services, pointed their requirements to this branch, pip  installed, and tox tested. They both passed without issues.