### PR TITLE
Reduce Breadcrumb Size

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,10 +2,17 @@
 Changelog
 =========
 
-Version 1.1.0
+Version 2.1.0
 ==============
 
-Release TBD
+Released 2018-07-19
+
+- Reduce bread crumb message size
+
+Version 2.0.0
+==============
+
+Released 2018-07-05
 
 - Update the message schema to a derivative of schema.org's MusicAlbum_
 - Add ``fanout`` to generate unique a ``job_id`` for outgoing messages sent by
@@ -18,6 +25,8 @@ Release TBD
 - Add ``Optional`` track level ``grid`` validation
 - Swapped ``offers`` date parsing validation from
   ``voluptuous.Datetime`` -> ``python-dateutil.parser``
+- Add ``None`` as acceptable for Optional fields in the product document schema
+- Handle ``None`` in OffsetAwareDatetime
 
 Version 1.0.0
 =============

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -200,8 +200,6 @@ async def prepare_incoming_message(app, message):
 
     if 'events' not in message:
         message['events'] = []
-    elif message['events']:
-        message['events'][-1]['message'] = deepcopy(message['message'])
 
     message['events'].append({
         'app': app.name,

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -67,11 +67,11 @@ async def test_job_id_is_preserved(test_app):
 
 
 @pytest.mark.asyncio
-async def test_message_is_hoisted_to_previous_event(test_app):
-    """Test that the message is copied to the previous event."""
+async def test_app_is_hoisted_to_previous_event(test_app):
+    """Test that the app is copied to the previous event."""
     actual = await prepare_incoming_message(
-        test_app, {'events': [{}], 'message': 1})
-    assert actual['events'][-2]['message'] == 1
+        test_app, {'message': 1})
+    assert actual['events'][-1]['app'] == test_app.name
 
 
 @pytest.mark.parametrize('key', (


### PR DESCRIPTION
For each bread crumb event, we no longer need to capture `message['message']`. It's causing our message sizes to get out of control, and if someone really needs to get that message, there is a `job_id` that can be used as a reference to the original message itself.

Here are the following stats for message size changes across our 3 main pipelines:

```
MUSIC

21,862 messages = 2.5GB (Old Message Structure) 
21.862 messages = 158MB (New Message Structure)
93.68% Decrease In Message Size

NAPSTER

23,405 messages = 16GB (Old Message Structure)
23,405 messages = 146MB (New Message Structure)
99.1% Decrease In Message Size

MRI

21,792 messages = 1GB (Old Message Structure)
21,792 messages = 69MB (New Message Structure)
93.1% Decrease In Message Size
```