### PR TITLE
Added uppercased ISRC as part of normalization.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Version 2.1.1
+==============
+
+Released 2018-07-24
+
+- Add Uppercase to ISRC normalization
+
 Version 2.1.0
 ==============
 

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -98,7 +98,7 @@ def normalize_isrc(isrc):
 
     ISRCs can be displayed with dashes to make them easier to read. The
     values themselves, however, do not contain them. Before comparing
-    one ISRC to another, any dashes should be stripped.
+    one ISRC to another, any dashes should be stripped, and uppercased.
 
     Args:
         isrc (str): The ISRC value to be transformed.
@@ -109,7 +109,7 @@ def normalize_isrc(isrc):
     .. versionadded:: 1.1.0
 
     """
-    return isrc.replace('-', '')
+    return isrc.replace('-', '').upper()
 
 
 def normalize_upc(upc):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -24,6 +24,16 @@ def test_normalize_isrc_unchanged(isrc):
     assert isrc == pipeline.normalize_isrc(isrc)
 
 
+@pytest.mark.parametrize('isrc, expected', (
+    ('qm-9k-3120-0284', 'QM9K31200284'),
+    ('qm9k31200284', 'QM9K31200284'),
+))
+def test_upper_cased_normalize_isrc(isrc, expected):
+    """Test that ISRCs with dashes are transformed."""
+    actual = pipeline.normalize_isrc(isrc)
+    assert actual == expected
+
+
 @pytest.mark.parametrize('upc, expected', (
     ('00616892587125', '616892587125'),
     ('00076743106828', '076743106828'),


### PR DESCRIPTION
ISRC needs to be uppercased to ensure a proper match throughout the pipeline.