### PR TITLE
Fix semantic version

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-Version 2.2.1
+Version 2.2.0
 ==============
 
 Released 2018-09-13

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pipeline',
-    version='2.2.1',
+    version='2.2.0',
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'Henson>=0.5.0',


### PR DESCRIPTION
Incrementing the minor version requires resetting the patch version, so `2.1.1` becomes `2.2.0` rather than `2.2.1`.