### PR TITLE
Genre Is Optional

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Version 2.3.0
+==============
+
+Released 2019-02-13
+
+- Update ``genre`` to be ``Optional``
+
 Version 2.2.0
 ==============
 

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -321,7 +321,7 @@ product = SchemaAllRequired({
     'copyright': copyright,
     'duration': str,
     'explicitLyrics': bool,
-    'genre': str,
+    Optional('genre'): Any(None, str),
     Optional('id'): Any(None, int),
     Optional('internalId'): Any(None, str),
     Optional('media'): Any(None, media),
@@ -356,7 +356,7 @@ Args:
 track_schema = product.schema.copy()
 track_schema.update({
     Optional('alternativeName'): Any(None, str),
-    'genre': str,
+    Optional('genre'): Any(None, str),
     Optional('grid'): Any(None, str),
     'index': int,
     'isrcCode': str,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pipeline',
-    version='2.2.0',
+    version='2.3.0',
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'Henson>=0.5.0',

--- a/tests/data/schema/valid-nulled-schema.json
+++ b/tests/data/schema/valid-nulled-schema.json
@@ -81,7 +81,7 @@
             },
             "duration": "PT3M55S",
             "explicitLyrics": false,
-            "genre": "Deutschspr. HipHop /- Rap",
+            "genre": null,
             "grid": null,
             "index": 0,
             "internalId": null,


### PR DESCRIPTION
Some deliveries have tracks that don't have `<Genre>`, but we shouldn't block these products from making their way through the pipeline, so here, we're making it `Optional`.