### PR TITLE
Add support for exchange_name on send.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Version 2.4.0
+==============
+
+Released 2019-02-22
+
+- Support for ``exchange_name`` added
+
 Version 2.3.0
 ==============
 

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -250,7 +250,8 @@ async def send_error(message, *, producer):
     await producer.error(serialized_message)
 
 
-async def send_message(message, *, producer, routing_key=None):
+async def send_message(
+        message, *, producer, exchange_name=None, routing_key=None):
     """Send an outgoing message.
 
     ``message`` will be updated with the common message structure and
@@ -263,12 +264,15 @@ async def send_message(message, *, producer, routing_key=None):
             through to the producer's ``send`` method. Defaults to
             ``None``.
 
-    .. versionchanged:: 1.0.0
+    .. versionchanged:: 2.4.0
 
-        The ``event`` argument is being removed because
-        ``prepare_outgoing_message`` no longer accepts it.
+        Support for ``exchange_name`` added.
     """
     prepared_message = prepare_outgoing_message(message)
     # TODO: This should be done in a separate step.
     serialized_message = await jsonify(producer.app, prepared_message)
-    await producer.send(serialized_message, routing_key=routing_key)
+    await producer.send(
+        serialized_message,
+        exchange_name=exchange_name,
+        routing_key=routing_key,
+    )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pipeline',
-    version='2.3.0',
+    version='2.4.0',
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'Henson>=0.5.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,9 +33,10 @@ class Producer:
         """Mock send an error message."""
         self.sent_error = message
 
-    async def send(self, message, *, routing_key=None):
+    async def send(self, message, *, exchange_name=None, routing_key=None):
         """Mock send a message."""
         self.sent_message = message
+        self.exchange_name = exchange_name
         self.routing_key = routing_key
 
 


### PR DESCRIPTION
Currently send_message only accepts routing_key. This change allows the use of the specified exchange_name as the outbound exchange to route to. 

This change allows for specifying the exchange we would like to send a message to, similar to the routing_key change prior.

This also bumps up the version from 2.3.0 to 2.4.0, but this change should keep backward compatibility. 
