### PR TITLE
Updating artist schema to include multiple artists

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 2.5.0
+==============
+
+Released 2020-03-25
+
+- Adding an optional ``artists`` key in the artist schema,
+  this lists the individual artists if present in the DDEX delivery.
+
 Version 2.4.0
 ==============
 

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -194,6 +194,12 @@ def validate_schema(schema, message, logger=None):
 # shared sub-types
 artist = SchemaAllRequired({
     'name': str,
+    Optional('artists'): [Any(
+        None, Schema({
+            'artist_name': str,
+            'artist_role': str,
+            'sequence_number': Any(None, int),
+        }))],
     Optional('url'): Any(None, str),
 })
 """Schema to validate an artist.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pipeline',
-    version='2.4.0',
+    version='2.5.0',
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'Henson>=0.5.0',

--- a/tests/data/schema/valid-nulled-schema.json
+++ b/tests/data/schema/valid-nulled-schema.json
@@ -3,7 +3,8 @@
     "albumReleaseType": "Single",
     "amwKey": "EMS_4260100940705",
     "artist": {
-        "name": "Fäbson"
+        "name": "Fäbson",
+        "artists": []
     },
     "catalogNumber": "4260100940705",
     "copyright": {
@@ -73,7 +74,8 @@
             "alternativeName": "Mama",
             "amwKey": "EMS_4260100940705_DEUD91708166_1_1",
             "artist": {
-                "name": "Fäbson"
+                "name": "Fäbson",
+                "artists": []
             },
             "copyright": {
                 "text": "ILM Records",

--- a/tests/data/schema/valid.json
+++ b/tests/data/schema/valid.json
@@ -3,7 +3,14 @@
     "albumReleaseType": "Album",
     "amwKey": "iHM_UPC",
     "artist": {
-        "name": "Artist"
+        "name": "Artist",
+        "artists": [
+            {
+                "artist_name": "Artist",
+                "artist_role": "Main Artist",
+                "sequence_number": 1
+            }
+        ]
     },
     "catalogNumber": "catalognumber",
     "copyright": {
@@ -53,7 +60,14 @@
             "action": "upsert",
             "amwKey": "iHM_UPC_ISRC",
             "artist": {
-                "name": "Artist"
+                "name": "Artist",
+                "artists": [
+                    {
+                        "artist_name": "Artist",
+                        "artist_role": "Main Artist",
+                        "sequence_number": 1
+                    }
+                ]
             },
             "copyright": {
                 "text": "2015 Copyright",
@@ -102,7 +116,14 @@
             "action": "upsert",
             "amwKey": "iHM_UPC_ISRC",
             "artist": {
-                "name": "Artist"
+                "name": "Artist",
+                "artists": [
+                    {
+                        "artist_name": "Artist",
+                        "artist_role": "Main Artist",
+                        "sequence_number": 1
+                    }
+                ]
             },
             "copyright": {
                 "text": "2015 Copyright",


### PR DESCRIPTION
This PR updates the artist key in the product document to optionally include an `artists` key which includes a list of individually listed artists in the DDEX delivery.

This also bumps up the version from 2.4.0 to 2.5.0, but this change should keep backward compatibility as DDEX deliveries might not list individual artists. Also this should work for non-ddex, hence `artists` being optional.