### PR TITLE
add codeartifact setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,32 @@ language: python
 python: 3.6
 
 # Install the test runner.
-install: pip install tox
+install:
+  - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+  - unzip awscliv2.zip
+  - sudo ./aws/install
+  - pip install tox
 
 # Run each environment separately so we get errors back from all of them.
-env:
-  - TOX_ENV=py36
-  - TOX_ENV=pep8
-  - TOX_ENV=docs
-script:
-  - tox -e $TOX_ENV
+jobs:
+  include:
+    - stage: test
+      name: "Tests"
+      env: TOX_ENV=py36
+      script: tox -e $TOX_ENV
+    - stage: pep8
+      name: "Pep8 Check"
+      env: TOX_ENV=pep8
+      script: tox -e $TOX_ENV
+    - stage: deploy
+      name: "Deploy to CodeArtifact"
+      script: ./scripts/deploy.sh
+
+stages:
+  - test
+  - pep8
+  - name: deploy
+    if: branch = master AND NOT type in (pull_request)
 
 # Control the branches that get built.
 branches:

--- a/README.rst
+++ b/README.rst
@@ -3,3 +3,22 @@ Pipeline
 ========
 
 Common utilities used by the Ingestion Pipeline.
+
+-----------------------
+Deploying a new version
+-----------------------
+
+To manually deploy/test a new version:
+
+* Increment the version in setup.py, make sure CodeArtifact doesn't already have a repo for that version.
+
+* Make sure `dist` directory is empty, then follow instructions [here](https://github.com/iheartradio/content-platform-documentation/blob/master/private_python_modules/README.md#publishing-with-twine)
+
+When a branch is merged to master, a Travis job will build and deploy the version that's in `setup.py`.
+
+**WARNING:**
+If you don't delete the version you uploaded for testing, and it conflicts with the final `setup.py` version when the
+branch is merged, this will result in a conflict error and the build will fail.
+
+If you redeploy a new version of the same version tag, clear pip cache in dependent repos:
+`rm -rf ~/Library/Caches/pip/*`

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+export TWINE_USERNAME=aws
+export TWINE_PASSWORD=`aws codeartifact get-authorization-token --domain content-platform --domain-owner 827541288795 --query authorizationToken --output text`
+export TWINE_REPOSITORY_URL=https://content-platform-827541288795.d.codeartifact.us-east-1.amazonaws.com/pypi/content-platform/
+# upgrading pip to resolve dependency issue
+# https://travis-ci.community/t/cant-deploy-to-pypi-anymore-pkg-resources-contextualversionconflict-importlib-metadata-0-18/10494/26
+pip install --upgrade pip
+pip install twine
+python setup.py sdist bdist_wheel
+twine upload --verbose --repository pipeline-ihr dist/*

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='pipeline',
+    name='pipeline-ihr',
     version='2.5.0',
     packages=find_packages(exclude=['tests']),
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -10,17 +10,6 @@ commands =
     python -m coverage run -m pytest --strict {posargs: tests}
     python -m coverage report -m --include="pipeline/*"
 
-[testenv:docs]
-basepython = python3.6
-deps =
-    doc8
-    sphinx
-    sphinx_rtd_theme
-    sphinxcontrib-napoleon
-commands =
-    sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
-    doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
-
 [testenv:pep8]
 basepython = python3.6
 skip_install = True


### PR DESCRIPTION
This PR:

- Removes sphinx docs build step
- Updates travis and build related files to enable automatically building and pushing this library to CodeArtifact

Things I specifically need sign off on:
- I've renamed the library from `pipeline` to `pipeline-ihr`. This is my personal recommendation to avoid the headache of naming conflicts with PyPi. There are additional steps we should take to mitigate this, such as setting the pip `--index-url` flag while installing private repos. But if we depart from using that process in the future, and to improve ease of working with this library in general, I think adding the ihr suffix gives us some redundancy in avoiding non-malicious naming conflicts.

- Getting rid of sphinx

More info on how unreliably pip decides which index to get packages from:
https://pydist.com/blog/extra-index-url