### PR TITLE
[IHRACP-4621] Adding an 'action' key in the offers schema.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 2.7.0
+==============
+
+- Adding an ``action`` key in the offers schema, this specifies the
+  action [``upsert`` or ``takedown``] at offers level.
+
 Version 2.6.0
 ==============
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ version = release.rsplit('.', 1)[0]
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -295,6 +295,7 @@ Args:
 """
 
 offer = SchemaAllRequired({
+    'action': str,
     'commercialModelType': CommercialModelType,
     'licensee': str,
     Optional('price'): Any(None, str),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pipeline',
-    version='2.6.0',
+    version='2.7.0',
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'Henson>=0.5.0',

--- a/tests/data/schema/valid-nulled-schema.json
+++ b/tests/data/schema/valid-nulled-schema.json
@@ -28,6 +28,7 @@
     "numVolumes": 1,
     "offers": [
         {
+            "action": "upsert",
             "commercialModelType": "SubscriptionModel",
             "licensee": "iheart",
             "territoryCode": "WW",
@@ -39,6 +40,7 @@
             "validThrough": "2100-01-01T00:00:00.000000+00:00"
         },
         {
+            "action": "upsert",
             "commercialModelType": "AdvertisementSupportedModel",
             "licensee": "iheart",
             "territoryCode": "WW",
@@ -99,6 +101,7 @@
             "number": 1,
             "offers": [
                 {
+                    "action": "upsert",
                     "commercialModelType": "SubscriptionModel",
                     "licensee": "iheart",
                     "territoryCode": "AU",
@@ -110,6 +113,7 @@
                     "validThrough": "2100-01-01T00:00:00.000000+00:00"
                 },
                 {
+                    "action": "upsert",
                     "commercialModelType": "AdvertisementSupportedModel",
                     "licensee": "iheart",
                     "territoryCode": "AU",

--- a/tests/data/schema/valid-offer.json
+++ b/tests/data/schema/valid-offer.json
@@ -1,4 +1,5 @@
 {
+    "action": "upsert",
     "commercialModelType": "SubscriptionModel",
     "licensee": "iheart",
     "territoryCode": "US",

--- a/tests/data/schema/valid.json
+++ b/tests/data/schema/valid.json
@@ -29,6 +29,7 @@
     "numVolumes": 1,
     "offers": [
         {
+            "action": "upsert",
             "commercialModelType": "AdvertisementSupportedModel",
             "licensee": "iHeartMedia",
             "territoryCode": "US",
@@ -101,6 +102,7 @@
             },
             "offers": [
                 {
+                    "action": "upsert",
                     "commercialModelType": "SubscriptionModel",
                     "licensee": "iHeartMedia",
                     "territoryCode": "US",


### PR DESCRIPTION
# Description

Adding an `action` key in the offers schema. This specifies the action (`upsert` or `takedown`) at offers level.
And this upgrade to pipeline is required in order to update `non-takedown` offers also that are coming with the takedown xml deliveries.

### Fixes # [IHRACP 4621](https://ihm-it.atlassian.net/browse/IHRACP-4621)

# New Feature

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested via Keystone & Overseer tool. Also the unit tests are passed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Developer / Author Notes
Updated the configuration according to the latest upgrades in sphinx. Please refer [here](https://github.com/sphinx-doc/sphinx/issues/10474)